### PR TITLE
Remove explicit close method

### DIFF
--- a/src/ansys/twin/evaluate/evaluate.py
+++ b/src/ansys/twin/evaluate/evaluate.py
@@ -28,7 +28,11 @@ class TwinModel:
         self._instantiate_twin_model()
 
     def __del__(self):
-        self._close()
+        """
+        (internal) Close twin runtime when object is garbage collected.
+        """
+        if self._twin_runtime is not None:
+            self._twin_runtime.twin_close()
 
     def _check_model_filepath_is_valid(self, model_filepath):
         """
@@ -43,13 +47,6 @@ class TwinModel:
             msg += '\nPlease provide existing filepath to initialize the TwinModel object.'
             raise self._raise_error(msg)
         return True
-
-    def _close(self):
-        """
-        (internal) Close twin runtime
-        """
-        if self._twin_runtime is not None:
-            self._twin_runtime.twin_close()
 
     def _create_dataframe_inputs(self, inputs_df: pd.DataFrame):
         """Create a dataframe inputs that satisfies the conventions of the runtime SDK batch mode evaluation, that are:
@@ -243,12 +240,6 @@ class TwinModel:
         Return None if model filepath is not valid.
         """
         return self._model_filepath
-
-    def close(self):
-        """
-        Close Twin Model and its internal variables.
-        """
-        self._close()
 
     def initialize_evaluation(self, parameters: dict = None, inputs: dict = None, json_config_filepath: str = None):
         """

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -276,3 +276,9 @@ class TestEvaluate:
         with pytest.raises(TwinModelError) as e:
             twin.initialize_evaluation(json_config_filepath='filepath_does_not_exist')
         assert 'Please provide an existing filepath to initialize the twin model evaluation' in str(e)
+
+    def test_close_method(self):
+        model_filepath = os.path.join('data', 'CoupleClutches_22R2_other.twin')
+        twin = TwinModel(model_filepath=model_filepath)
+        twin = TwinModel(model_filepath=model_filepath)
+        twin = TwinModel(model_filepath=model_filepath)


### PR DESCRIPTION
# What this PR does?
Remove any public close method to avoid possible "Windows fatal exception" if the method is called twice on the same reference. The TwinRuntime object that is owned by a TwinModel is twin_close() only by the build-in __del__ method of the TwinModel. This should prevent any misusage of the TwinRuntime.twin_close() method.
 
# Type(s) of change
- [ ] Non-functional changes (e.g. code styling, development documentation, policy-related and etc.)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
- [x] New unit tests added
- [x] Current unit tests passed
- [x] Existing unit tests updated
- [x] Manual/interactive tested