### PR TITLE
Add docstring to public enums and expose twin runtime as public API.

### DIFF
--- a/pytwin/__init__.py
+++ b/pytwin/__init__.py
@@ -37,3 +37,9 @@ PUBLIC API TO PYTWIN EVALUATE
 """
 from .evaluate import TwinModel
 from .evaluate import TwinModelError
+
+"""
+PUBLIC API TO PYTWIN RUNTIME 
+"""
+from .twin_runtime import TwinRuntime
+from .twin_runtime import TwinRuntimeError

--- a/pytwin/settings.py
+++ b/pytwin/settings.py
@@ -6,6 +6,10 @@ from enum import Enum
 
 
 class PyTwinLogLevel(Enum):
+    """
+    Enum to choose logging level to be used by all pytwin objects.
+    It follows standard python logging levels.
+    """
     PYTWIN_LOG_DEBUG = logging.DEBUG
     PYTWIN_LOG_INFO = logging.INFO
     PYTWIN_LOG_WARNING = logging.WARNING
@@ -14,6 +18,17 @@ class PyTwinLogLevel(Enum):
 
 
 class PyTwinLogOption(Enum):
+    """
+    Enum to choose logging options to be used by all pytwin objects.
+
+    PYTWIN_LOGGING_OPT_FILE:
+        Redirect logging to the pytwin log file stored in the pytwin working directory.
+    PYTWIN_LOGGING_OPT_CONSOLE:
+        Redirect logging to console.
+    PYTWIN_LOGGING_OPT_NOLOGGING:
+        Disable pytwin logging.
+
+    """
     PYTWIN_LOGGING_OPT_FILE = 0  # Redirect logging to pytwin log file
     PYTWIN_LOGGING_OPT_CONSOLE = 1  # Redirect logging to console
     PYTWIN_LOGGING_OPT_NOLOGGING = 2  # No logging


### PR DESCRIPTION
# What this PR does?
This PR add docstring to the `PyTwinLogLevel` and `PyTwinLogOption` enums. 

It also adds the `TwinRuntime` class and associated error `TwinRunTimeError` to the public API of the `pytwin` package. The later eases runtime import, since `from pytwin import TwinRuntime` is now available.

## Type(s) of change
- [x] Non-functional changes (e.g. code styling, development documentation, policy-related and etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
- [ ] New unit tests added
- [x] Current unit tests passed
- [ ] Existing unit tests updated
- [ ] Manual/interactive tested