### PR TITLE
Add field inputs and outputs to batch evaluation

### DIFF
--- a/examples/evaluate/06-TBROM_input_field.py
+++ b/examples/evaluate/06-TBROM_input_field.py
@@ -221,3 +221,4 @@ batch_results = twin_model.evaluate_batch(inputs_df=input_df,
                                           field_inputs={romname: {fieldname: inputfieldsnapshots}})
 print(batch_results)
 output_snapshots = twin_model.generate_snapshot_batch(batch_results, romname)
+print(output_snapshots)

--- a/examples/evaluate/06-TBROM_input_field.py
+++ b/examples/evaluate/06-TBROM_input_field.py
@@ -47,9 +47,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 from pytwin import TwinModel, download_file
 
-twin_file = download_file(
-    "ThermalTBROM_FieldInput_23R1.twin", "twin_files", force_download=True
-)  # , force_download=True)
+twin_file = download_file("ThermalTBROM_FieldInput_23R1.twin", "twin_files", force_download=True)
 inputfieldsnapshots = [
     download_file("TEMP_1.bin", "twin_input_files/inputFieldSnapshots", force_download=True),
     download_file("TEMP_2.bin", "twin_input_files/inputFieldSnapshots", force_download=True),

--- a/examples/evaluate/06-TBROM_input_field.py
+++ b/examples/evaluate/06-TBROM_input_field.py
@@ -186,9 +186,9 @@ for i in range(0, len(rom_inputs)):
     outputs.append(max(norm_vector_field(outfieldns)))
     results.append(outputs)
 
-sim_results = pd.DataFrame(results,
-                           columns=[input_name] + output_name_without_mcs + ["MaxDefSnapshot", "MaxDefSnapshotNs"],
-                           dtype=float)
+sim_results = pd.DataFrame(
+    results, columns=[input_name] + output_name_without_mcs + ["MaxDefSnapshot", "MaxDefSnapshotNs"], dtype=float
+)
 
 ###############################################################################
 # Plot results
@@ -209,14 +209,8 @@ dp_input = {input_name: rom_inputs[0]}
 dp_field_input = {romname: {fieldname: inputfieldsnapshots[0]}}
 twin_model.initialize_evaluation(inputs=dp_input, field_inputs=dp_field_input)
 # creation of the input DataFrame including input field snapshots
-input_df = pd.DataFrame(
-    {
-        "Time": [0.0, 1.0, 2.0],
-        input_name_without_mcs[0]: rom_inputs
-    }
-)
-batch_results = twin_model.evaluate_batch(inputs_df=input_df,
-                                          field_inputs={romname: {fieldname: inputfieldsnapshots}})
+input_df = pd.DataFrame({"Time": [0.0, 1.0, 2.0], input_name_without_mcs[0]: rom_inputs})
+batch_results = twin_model.evaluate_batch(inputs_df=input_df, field_inputs={romname: {fieldname: inputfieldsnapshots}})
 print(batch_results)
 output_snapshots = twin_model.generate_snapshot_batch(batch_results, romname)
 print(output_snapshots)

--- a/examples/evaluate/06-TBROM_input_field.py
+++ b/examples/evaluate/06-TBROM_input_field.py
@@ -213,4 +213,3 @@ input_df = pd.DataFrame({"Time": [0.0, 1.0, 2.0], input_name_without_mcs[0]: rom
 batch_results = twin_model.evaluate_batch(inputs_df=input_df, field_inputs={romname: {fieldname: inputfieldsnapshots}})
 print(batch_results)
 output_snapshots = twin_model.generate_snapshot_batch(batch_results, romname)
-print(output_snapshots)

--- a/src/ansys/pytwin/evaluate/twin_model.py
+++ b/src/ansys/pytwin/evaluate/twin_model.py
@@ -936,7 +936,7 @@ class TwinModel(Model):
             this input is kept constant to its initialization value. The column header must match with a
             twin model input name.
         field_inputs : dict (optional)
-            Dictionary of snapshot file pathes that must be used as field input at all time instants
+            Dictionary of snapshot file paths that must be used as field input at all time instants
             given by the 'inputs_df' argument. One file path must be given per time instant, for a field input
              of a TBROM included in the twin model, using following dictionary format:
             {"tbrom_name": {"field_input_name": [snapshotpath_t0, snapshotpath_t1, ... ]}}
@@ -973,9 +973,9 @@ class TwinModel(Model):
         >>> snapshot_filepath_t0 = 'path_to_snasphot_t0.twin'
         >>> twin_model.initialize_evaluation(field_inputs={romname: {fieldname: snapshot_filepath_t0})
         >>> inputs_df = pd.DataFrame({'Time': [0., 1., 2.]})
-        >>> snapshot_filepathes = ['path_to_snasphot_t0.twin', 'path_to_snasphot_t1.twin', 'path_to_snasphot_t2.twin']
+        >>> snapshot_filepaths = ['path_to_snasphot_t0.twin', 'path_to_snasphot_t1.twin', 'path_to_snasphot_t2.twin']
         >>> batch_results = twin_model.evaluate_batch(inputs_df=inputs_df,\
-        field_inputs={romname: {fieldname: snapshot_filepathes})
+        field_inputs={romname: {fieldname: snapshot_filepaths})
         >>> output_snapshots = twin_model.generate_snapshot_batch(batch_results, romname)
         """
         self._log_key = "EvaluateBatch"

--- a/src/ansys/pytwin/evaluate/twin_model.py
+++ b/src/ansys/pytwin/evaluate/twin_model.py
@@ -1504,7 +1504,8 @@ class TwinModel(Model):
     def generate_snapshot_batch(self, batch_results: pd.DataFrame, rom_name: str, named_selection: str = None):
         """
         Generate several field snapshots based on historical batch results of the Twin, for the full field or a specific
-        part. It returns a list of the paths of the different snapshots written on disk.
+        named selection. It returns a list of the paths of the different snapshots written on disk.
+
         Parameters
         ----------
         batch_results : pandas.DataFrame
@@ -1514,12 +1515,14 @@ class TwinModel(Model):
             Name of the TBROM considered to generate the snapshot.
         named_selection : str (optional)
             Named selection on which the snasphot has to be generated.
+
         Raises
         ------
         TwinModelError:
             If the :func:`pytwin.TwinModel.initialize_evaluation` method has not been called before.
             If rom_name is not included in the Twin's list of TBROM
             If name_selection is not included in the TBROM's list of Named Selections
+
         Examples
         --------
         >>> import pandas as pd

--- a/src/ansys/pytwin/evaluate/twin_model.py
+++ b/src/ansys/pytwin/evaluate/twin_model.py
@@ -163,7 +163,7 @@ class TwinModel(Model):
                 msg = self._error_msg_for_rom_input_connection(tbrom_name)
                 raise self._raise_error(msg)
 
-            if type(snapshot_filepath) is str:
+            if (type(snapshot_filepath) is str) or (snapshot_filepath is None):
                 self._check_snapshot_filepath(snapshot_filepath, tbrom, fieldname)
 
             if t_count is not None:

--- a/src/ansys/pytwin/evaluate/twin_model.py
+++ b/src/ansys/pytwin/evaluate/twin_model.py
@@ -1013,7 +1013,7 @@ class TwinModel(Model):
                             for mc_name, mc_value in infmcs.items():
                                 header_name = self._field_input_port_name(field_name, mc_idx, tbrom_name)
                                 if i == 0:
-                                    _inputs_df[header_name] = [0] * t_count
+                                    _inputs_df[header_name] = [0.] * t_count
                                 _inputs_df.at[i, header_name] = mc_value
                                 mc_idx += 1
 

--- a/src/ansys/pytwin/evaluate/twin_model.py
+++ b/src/ansys/pytwin/evaluate/twin_model.py
@@ -169,8 +169,9 @@ class TwinModel(Model):
             if t_count is not None:
                 if type(snapshot_filepath) is list:
                     if len(snapshot_filepath) != t_count:
-                        msg = self._error_msg_input_snapshot_count(found_count=len(snapshot_filepath),
-                                                                   expected_count=t_count)
+                        msg = self._error_msg_input_snapshot_count(
+                            found_count=len(snapshot_filepath), expected_count=t_count
+                        )
                         raise self._raise_error(msg)
 
                     for i in snapshot_filepath:
@@ -285,7 +286,9 @@ class TwinModel(Model):
         return msg
 
     def _error_msg_input_snapshot_count(self, found_count: int, expected_count: int):
-        msg = f"[InputSnapshotCount]The provided number of snapshot file path ({found_count}) to be used as input field "
+        msg = (
+            f"[InputSnapshotCount]The provided number of snapshot file path ({found_count}) to be used as input field "
+        )
         msg += f"must equal the number of time instants given in the batch data frame ({expected_count})."
         return msg
 
@@ -657,11 +660,9 @@ class TwinModel(Model):
                 for name, snp_path in field_inputs.items():
                     self._update_field_input(tbrom, name, snp_path)
 
-    def _update_field_input(self,
-                            tbrom: TbRom,
-                            field_input_name: str,
-                            snapshot_filepath: str,
-                            update_twin_runtime: bool = True):
+    def _update_field_input(
+        self, tbrom: TbRom, field_input_name: str, snapshot_filepath: str, update_twin_runtime: bool = True
+    ):
         """
         Update Twin's current inputs states based on tbrom attributes
         """
@@ -1003,14 +1004,16 @@ class TwinModel(Model):
                 if self._check_tbrom_input_field_dict_is_valid(tbrom_name, field_inputs_dict, t_count):
                     for field_name, snapshot_filepaths in field_inputs_dict.items():
                         for i, snapshot_filepath in enumerate(snapshot_filepaths):
-                            infmcs = self._update_field_input(tbrom=self._tbroms[tbrom_name],
-                                                              field_input_name=field_name,
-                                                              snapshot_filepath=snapshot_filepath)
+                            infmcs = self._update_field_input(
+                                tbrom=self._tbroms[tbrom_name],
+                                field_input_name=field_name,
+                                snapshot_filepath=snapshot_filepath,
+                            )
                             mc_idx = 0
                             for mc_name, mc_value in infmcs.items():
                                 header_name = self._field_input_port_name(field_name, mc_idx, tbrom_name)
                                 if i == 0:
-                                    _inputs_df[header_name] = [0]*t_count
+                                    _inputs_df[header_name] = [0] * t_count
                                 _inputs_df.at[i, header_name] = mc_value
                                 mc_idx += 1
 
@@ -1564,9 +1567,9 @@ class TwinModel(Model):
             return outpath
 
         except Exception as e:
-                msg = f"Something went wrong while generating the snapshot:"
-                msg += f"\n{str(e)}."
-                self._raise_error(msg)
+            msg = f"Something went wrong while generating the snapshot:"
+            msg += f"\n{str(e)}."
+            self._raise_error(msg)
 
     def generate_points(self, named_selection: str, rom_name: str, on_disk: bool = True):
         """


### PR DESCRIPTION
- Add `field_inputs` argument to `TwinModel.evaluation_batch(...)`
- Add `generate_snapshot_batch(...)` method to `TwinModel `
- Update example 06
- Add unit tests