### PR TITLE
[Fix] Update RomViewerSharedLib.so in unit test files and update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         if: ${{ matrix.os }} == "ubuntu-20.04"
         run: |
           sudo apt-get update
-          sudo apt-get install libosmesa6
+          sudo apt-get install libegl1
 
       - name: Run pytest
         uses: ansys/actions/tests-pytest@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
            python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - name: Install Ubuntu dependencies for RomViewerSharedLib.so
-        if: ${{ matrix.os }} == "ubuntu-20.04"
+        if: matrix.os == 'ubuntu-20.04'
         run: |
           sudo apt-get update
           sudo apt-get install libosmesa6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         if: ${{ matrix.os }} == "ubuntu-20.04"
         run: |
           sudo apt-get update
-          sudo apt-get install libegl1
+          sudo apt-get install libosmesa6
 
       - name: Run pytest
         uses: ansys/actions/tests-pytest@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,12 @@ jobs:
            os: [pytwin-win10, ubuntu-20.04]
            python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
+      - name: Install Ubuntu dependencies for RomViewerSharedLib.so
+        if: ${{ matrix.os }} == "ubuntu-20.04"
+        run: |
+          sudo apt-get update
+          sudo apt-get install libosmesa6
+
       - name: Run pytest
         uses: ansys/actions/tests-pytest@v4
         with:

--- a/tests/evaluate/test_tbrom.py
+++ b/tests/evaluate/test_tbrom.py
@@ -929,7 +929,7 @@ class TestTbRom:
     def test_tbrom_image_generation_at_initialization(self):
         reinit_settings()
         # model_filepath = download_file("ThermalTBROM_23R1_other.twin", "twin_files")
-        model_filepath = os.path.join(os.path.dirname(__file__), "data", "ThermalTBROM_23R1_other.twin")
+        model_filepath = os.path.join(os.path.dirname(__file__), "data", "ThermalTBROM_23R2.twin")
         twin = TwinModel(model_filepath=model_filepath)
         twin.initialize_evaluation()
 

--- a/tests/evaluate/test_tbrom.py
+++ b/tests/evaluate/test_tbrom.py
@@ -928,19 +928,20 @@ class TestTbRom:
 
     def test_tbrom_image_generation_at_initialization(self):
         reinit_settings()
-        model_filepath = download_file("ThermalTBROM_23R1_other.twin", "twin_files")
+        # model_filepath = download_file("ThermalTBROM_23R1_other.twin", "twin_files")
+        model_filepath = os.path.join(os.path.dirname(__file__), "data", "ThermalTBROM_23R1_other.twin")
         twin = TwinModel(model_filepath=model_filepath)
         twin.initialize_evaluation()
 
         # Verify IMAGE IS GENERATED AT INITIALIZATION
-        if sys.platform != "linux":
-            # TODO - Fix BUG755776
-            fp = twin.get_image_filepath(
-                rom_name=twin.tbrom_names[0],
-                view_name=twin.get_available_view_names(twin.tbrom_names[0])[0],
-                evaluation_time=0.0,
-            )
-            assert os.path.exists(fp)
+        #        if sys.platform != "linux":
+        # TODO - Fix BUG755776
+        fp = twin.get_image_filepath(
+            rom_name=twin.tbrom_names[0],
+            view_name=twin.get_available_view_names(twin.tbrom_names[0])[0],
+            evaluation_time=0.0,
+        )
+        assert os.path.exists(fp)
 
     def test_tbrom_getters_warning(self):
         reinit_settings()

--- a/tests/evaluate/test_tbrom.py
+++ b/tests/evaluate/test_tbrom.py
@@ -928,14 +928,10 @@ class TestTbRom:
 
     def test_tbrom_image_generation_at_initialization(self):
         reinit_settings()
-        # model_filepath = download_file("ThermalTBROM_23R1_other.twin", "twin_files")
         model_filepath = os.path.join(os.path.dirname(__file__), "data", "ThermalTBROM_23R2.twin")
         twin = TwinModel(model_filepath=model_filepath)
         twin.initialize_evaluation()
 
-        # Verify IMAGE IS GENERATED AT INITIALIZATION
-        #        if sys.platform != "linux":
-        # TODO - Fix BUG755776
         fp = twin.get_image_filepath(
             rom_name=twin.tbrom_names[0],
             view_name=twin.get_available_view_names(twin.tbrom_names[0])[0],


### PR DESCRIPTION
#Issue109
BUG755776
Update RomViewerSharedLib.so in unit test files with 23R2 version that has no more dependencies to libGL*.so
Update CI workflow to install libosmesa6 for Ubuntu workers in unit tests action.

