### PR TITLE
Maint/ci update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           sudo apt-get install libosmesa6
 
       - name: Setup headless display
-        if: matrix.os == 'pytwin-win10'
+        if: matrix.os == 'windows-latest'
         uses: pyvista/setup-headless-display-action@v2
 
       - name: Run pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
        matrix:
-           os: [pytwin-win10, ubuntu-20.04]
+           os: [windows-latest, ubuntu-20.04]
            python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: Install Ubuntu dependencies for RomViewerSharedLib.so


### PR DESCRIPTION
Modify CI workflow to use GitHub-hosted runner 'windows-latest' to run the unit testing (instead of 'pytwin-win10') which is still used to build documentation