### PR TITLE
add a fix for bug 1168769 

### DIFF
--- a/src/ansys/pytwin/evaluate/tbrom.py
+++ b/src/ansys/pytwin/evaluate/tbrom.py
@@ -282,10 +282,14 @@ class TbRom:
 
         propertiespath = os.path.join(tbrom_path, TbRom.TBROM_PROP)
         [nbpoints, nbmodes] = _read_properties(propertiespath)
-        self._nbpoints = int(nbpoints / self._outdim)
+        # bug 1168769 (fixed in 2025R2)
+        pointpath = os.path.join(tbrom_path, TbRom.OUT_F_KEY, TbRom.TBROM_POINTS)
+        if os.path.exists(pointpath):
+            self._nbpoints = read_snapshot_size(pointpath) // 3
+        else:
+            self._nbpoints = int(nbpoints / self._outdim)
         self._nbmodes = nbmodes
 
-        pointpath = os.path.join(tbrom_path, TbRom.OUT_F_KEY, TbRom.TBROM_POINTS)
         self._has_point_file = self._read_points(pointpath)
 
         outpath = os.path.join(tbrom_path, TbRom.OUT_F_KEY, TbRom.TBROM_BASIS)

--- a/tests/evaluate/test_tbrom.py
+++ b/tests/evaluate/test_tbrom.py
@@ -146,6 +146,12 @@ Twin with 1 TBROM with tensor field
 """
 TEST_TB_ROM_TENSOR = os.path.join(os.path.dirname(__file__), "data", "twin_tbrom_stress_field.json")
 
+"""
+TEST_TB_ROM_NDOF
+Twin with Dynamic ROM and NDOF not properly defined (bug 1168769 fixed in 2025R2)
+"""
+TEST_TB_ROM_NDOF = os.path.join(os.path.dirname(__file__), "data", "twin_ndof.twin")
+
 
 def norm_vector_field(field: list):
     """Compute the norm of a vector field."""
@@ -1379,3 +1385,10 @@ class TestTbRom:
             model_filepath
         )  # instantiation should be fine without points
         assert int(dimensionality[0]) is 6
+
+    def test_tbrom_fix_bug_1168769(self):
+        model_filepath = TEST_TB_ROM_NDOF
+        try:
+            twinmodel = TwinModel(model_filepath=model_filepath)
+        except TwinModelError as e:
+            assert "cannot reshape array" not in str(e)


### PR DESCRIPTION
The number of DoF/points is not correctly written for release < 2025R2 for dynamic ROM with field. This PR proposes a fix to extract the number of points based on the points.bin in case the geometry file is embedded