### PR TITLE
Expose PyVista interpolation settings in `project_tbrom_on_mesh`, add masking option to only keep interpolated points

### DIFF
--- a/src/ansys/pytwin/evaluate/tbrom.py
+++ b/src/ansys/pytwin/evaluate/tbrom.py
@@ -388,6 +388,7 @@ class TbRom:
         target_mesh: pv.DataSet,
         interpolate: bool,
         named_selection: str = None,
+        nodal_values: bool = False,
         sharpness: float = 5.0,
         radius: float = 0.0001,
         strategy: str = "closest_point",
@@ -407,6 +408,8 @@ class TbRom:
         named_selection: str (optional)
             Named selection on which the mesh projection has to be performed. The default is ``None``, in which case the
             entire domain is considered.
+        nodal_values: bool (optional)
+            Control whether the interpolated results are returned as nodal values, or cell values (default)
         sharpness: float, default: 5.0
             Set the sharpness (i.e., falloff) of the Gaussian interpolation kernel. As the sharpness increases the
             effects of distant points are reduced.
@@ -476,8 +479,12 @@ class TbRom:
                     raise ValueError(
                         "[TbRomInterpolation]No valid points found. Check mesh size and interpolation settings"
                     )
-            interpolated_mesh = interpolated_points.point_data_to_cell_data()
-            self._outmeshbasis = np.array([interpolated_mesh.cell_data[str(i)] for i in range(0, nbmc)])
+            if not nodal_values:
+                interpolated_mesh = interpolated_points.point_data_to_cell_data()
+                self._outmeshbasis = np.array([interpolated_mesh.cell_data[str(i)] for i in range(0, nbmc)])
+            else:
+                interpolated_mesh = interpolated_points
+                self._outmeshbasis = np.array([interpolated_mesh.point_data[str(i)] for i in range(0, nbmc)])
 
         if interpolate and strategy == "mask_points":
             mesh_data = interpolated_mesh.copy()

--- a/src/ansys/pytwin/evaluate/tbrom.py
+++ b/src/ansys/pytwin/evaluate/tbrom.py
@@ -468,7 +468,7 @@ class TbRom:
                 n_points=n_points,
                 progress_bar=progress_bar,
             )
-            if strategy == "mask_points" or "null_value":
+            if strategy == "mask_points":
                 interpolated_points = interpolated_points.threshold(
                     value=0.5, scalars="vtkValidPointMask", preference="point", all_scalars=all_points
                 )

--- a/src/ansys/pytwin/evaluate/tbrom.py
+++ b/src/ansys/pytwin/evaluate/tbrom.py
@@ -140,7 +140,7 @@ def snapshot_to_array(snapshot_file, geometry_file):
 
     Examples
     --------
-    >>> from pytwin import snapshot_to_fea
+    >>> from pytwin import snapshot_to_array
     >>> snapshot_data = snapshot_to_array('snapshot.bin', 'points.bin')
     """
     n_g = read_snapshot_size(geometry_file)

--- a/src/ansys/pytwin/evaluate/tbrom.py
+++ b/src/ansys/pytwin/evaluate/tbrom.py
@@ -411,23 +411,17 @@ class TbRom:
         nodal_values: bool (optional)
             Control whether the interpolated results are returned as nodal values, or cell values (default)
         sharpness: float, default: 5.0
-            Set the sharpness (i.e., falloff) of the Gaussian interpolation kernel. As the sharpness increases the
-            effects of distant points are reduced.
+            Set the sharpness (i.e., falloff) of the Gaussian interpolation kernel.
         radius: float, default: 0.0001
             Specify the radius within which the basis points must lie.
         strategy: str, default: "closest_point"
-            Specify a strategy to use when encountering a "null" point during the interpolation process. Null points
-            occur when the local neighborhood (of nearby points to interpolate from) is empty. If the strategy is set to
-            ``'mask_points'``, then only cells with some or all valid points (according to the ``all_points`` setting)
-            are used in the projected SVD basis. If the strategy is set to ``'null_value'``, then the output data
-            value(s) are set to the ``null_value`` (specified in the output point data). Finally, the strategy
-            ``'closest_point'`` is to simply use the closest point to perform the interpolation.
+            Specify a strategy to use when encountering a "null" point during the interpolation process. Valid values
+            are ``'null_value'``, ``'mask_points'`` and ``'closest_point'``. If the ``'mask_points'`` strategy is used
+            then only non-null points are retained in the projected SVD basis.
         null_value: float, default: 0.0
-            Specify the null point value. When a null point is encountered then all components of each null tuple are
-            set to this value.
+            Specify the null point value.
         n_points: int, optional
-            If given, specifies the number of the closest points used to form the interpolation basis. This will
-            invalidate the radius argument in favor of an N closest points approach. This typically has poorer results.
+            If given, specifies the number of the closest points used to form the interpolation basis.
         all_points: bool, default: False
             When ``strategy='mask_points'``, when this value is ``True`` only cells where all points are valid are kept.
             When ``False`` cells are kept if any of their points are valid and invalid points are given the

--- a/src/ansys/pytwin/evaluate/twin_model.py
+++ b/src/ansys/pytwin/evaluate/twin_model.py
@@ -1873,6 +1873,7 @@ class TwinModel(Model):
         strategy: str = "closest_point",
         null_value: float = 0.0,
         n_points: int = None,
+        all_points: bool = False,
     ):
         """
         Project the field ROM data onto a targeted mesh, using the current states of the TwinModel. The returned PyVista
@@ -1896,21 +1897,24 @@ class TwinModel(Model):
             Set the sharpness (i.e., falloff) of the Gaussian interpolation kernel. As the sharpness increases the
             effects of distant points are reduced.
         radius : float, default: 0.0001
-            Specify the radius within which the basis points must lie.
-            for detailed description.
+            Specify the radius within which the interpolation basis points must lie.
         strategy : str, default: "closest_point"
             Specify a strategy to use when encountering a "null" point during the interpolation process. Null points
             occur when the local neighborhood (of nearby points to interpolate from) is empty. If the strategy is set to
-            ``'mask_points'``, then an output array is created that marks points as being valid (=1) or null
-            (invalid =0) (and the NullValue is set as well). If the strategy is set to ``'null_value'``, then the output
+            ``'mask_points'``, then only cells with some or all valid points (according to the ``all_points`` setting)
+            are included in the returned PyVista DataSet. If the strategy is set to ``'null_value'``, then the output
             data value(s) are set to the ``null_value`` (specified in the output point data). Finally, the strategy
             ``'closest_point'`` is to simply use the closest point to perform the interpolation.
         null_value : float, default: 0.0
-            Specify the null point value. When a null point is encountered then all components of each null tuple are
-            set to this value.
+            Specify the null point value. When a null point is encountered then all components of field ROM data
+            associated with that point are set to this value.
         n_points : int, optional
             If given, specifies the number of the closest points used to form the interpolation basis. This will
             invalidate the radius argument in favor of an N closest points approach. This typically has poorer results.
+        all_points: bool, default: False
+            When ``strategy='mask_points'``, when this value is ``True`` only cells where all points are valid are kept.
+            When ``False`` cells are kept if any of their points are valid and invalid points are given the
+            ``null_value``.
 
         Returns
         -------
@@ -1926,6 +1930,7 @@ class TwinModel(Model):
             If target_mesh is not a valid grid dataset
             If name_selection is not included in the TBROM's list of Named Selections
             If interpolate is True and no points file is available with the TBROM
+            If strategy is ``'mask_points'`` and all points are removed.
 
         TwinModelWarning:
             If interpolate is False and the targeted mesh has a number of cells and points different from TBROM point
@@ -1975,6 +1980,7 @@ class TwinModel(Model):
                     strategy=strategy,
                     null_value=null_value,
                     n_points=n_points,
+                    all_points=all_points,
                 )
                 self._update_tbrom_outmcs(self._tbroms[rom_name])
                 return self._tbroms[rom_name].field_on_mesh

--- a/src/ansys/pytwin/evaluate/twin_model.py
+++ b/src/ansys/pytwin/evaluate/twin_model.py
@@ -1863,7 +1863,16 @@ class TwinModel(Model):
             self._raise_error(msg)
 
     def project_tbrom_on_mesh(
-        self, rom_name: str, target_mesh: pv.DataSet, interpolate: bool, named_selection: str = None
+        self,
+        rom_name: str,
+        target_mesh: pv.DataSet,
+        interpolate: bool,
+        named_selection: str = None,
+        sharpness: float = 5.0,
+        radius: float = 0.0001,
+        strategy: str = "closest_point",
+        null_value: float = 0.0,
+        n_points: int = None,
     ):
         """
         Project the field ROM data onto a targeted mesh, using the current states of the TwinModel. The returned PyVista
@@ -1883,6 +1892,25 @@ class TwinModel(Model):
         named_selection: str (optional)
             Named selection from the ROM (i.e. subset of points cloud) that will be projected on the targeted mesh. The
             default is ``None``, in which case the entire domain is considered.
+        sharpness : float, default: 5.0
+            Set the sharpness (i.e., falloff) of the Gaussian interpolation kernel. As the sharpness increases the
+            effects of distant points are reduced.
+        radius : float, default: 0.0001
+            Specify the radius within which the basis points must lie.
+            for detailed description.
+        strategy : str, default: "closest_point"
+            Specify a strategy to use when encountering a "null" point during the interpolation process. Null points
+            occur when the local neighborhood (of nearby points to interpolate from) is empty. If the strategy is set to
+            ``'mask_points'``, then an output array is created that marks points as being valid (=1) or null
+            (invalid =0) (and the NullValue is set as well). If the strategy is set to ``'null_value'``, then the output
+            data value(s) are set to the ``null_value`` (specified in the output point data). Finally, the strategy
+            ``'closest_point'`` is to simply use the closest point to perform the interpolation.
+        null_value : float, default: 0.0
+            Specify the null point value. When a null point is encountered then all components of each null tuple are
+            set to this value.
+        n_points : int, optional
+            If given, specifies the number of the closest points used to form the interpolation basis. This will
+            invalidate the radius argument in favor of an N closest points approach. This typically has poorer results.
 
         Returns
         -------
@@ -1902,6 +1930,11 @@ class TwinModel(Model):
         TwinModelWarning:
             If interpolate is False and the targeted mesh has a number of cells and points different from TBROM point
             cloud. In that case, interpolate is automatically switched to True.
+
+        See Also
+        --------
+        pyvista.DataSetFilters.interpolate :
+            Detailed description of ``sharpness``, ``radius``, ``strategy``, ``null_value`` and ``n_points`` parameters.
 
         Examples
         --------
@@ -1933,7 +1966,16 @@ class TwinModel(Model):
                     interpolate_flag = interpolate
                 if interpolate_flag:
                     self._check_tbrom_points_file(rom_name)
-                self._tbroms[rom_name]._project_on_mesh(target_mesh, interpolate_flag, named_selection)
+                self._tbroms[rom_name]._project_on_mesh(
+                    target_mesh,
+                    interpolate_flag,
+                    named_selection,
+                    sharpness=sharpness,
+                    radius=radius,
+                    strategy=strategy,
+                    null_value=null_value,
+                    n_points=n_points,
+                )
                 self._update_tbrom_outmcs(self._tbroms[rom_name])
                 return self._tbroms[rom_name].field_on_mesh
 

--- a/src/ansys/pytwin/evaluate/twin_model.py
+++ b/src/ansys/pytwin/evaluate/twin_model.py
@@ -1868,6 +1868,7 @@ class TwinModel(Model):
         target_mesh: pv.DataSet,
         interpolate: bool,
         named_selection: str = None,
+        nodal_values: bool = False,
         sharpness: float = 5.0,
         radius: float = 0.0001,
         strategy: str = "closest_point",
@@ -1890,6 +1891,8 @@ class TwinModel(Model):
             Interpolation is recommended when point cloud data and mesh data are not ordered in the same way, and when
             the target mesh is different from the one used to generate the ROM. Interpolation is automatically enforced
             if the target mesh size (i.e. number of cells/points) is different from the point cloud size.
+        nodal_values: bool (optional)
+            Control whether the interpolated results are returned as nodal values, or cell values (default)
         named_selection: str (optional)
             Named selection from the ROM (i.e. subset of points cloud) that will be projected on the targeted mesh. The
             default is ``None``, in which case the entire domain is considered.
@@ -1975,6 +1978,7 @@ class TwinModel(Model):
                     target_mesh,
                     interpolate_flag,
                     named_selection,
+                    nodal_values=nodal_values,
                     sharpness=sharpness,
                     radius=radius,
                     strategy=strategy,

--- a/tests/evaluate/test_tbrom.py
+++ b/tests/evaluate/test_tbrom.py
@@ -1250,6 +1250,20 @@ class TestTbRom:
             log_str = log.readlines()
         assert "Switching interpolate flag from False to True" in "".join(log_str)
 
+        # Raise an exception if projection with masking removes all points
+        model_filepath = download_file("ThermalTBROM_FieldInput_23R1.twin", "twin_files")
+        twinmodel = TwinModel(model_filepath=model_filepath)
+        twinmodel.initialize_evaluation()
+        romname = twinmodel.tbrom_names[0]
+        nslist = twinmodel.get_named_selections(romname)
+        max_coord = twinmodel.generate_points(romname, on_disk=False).max()
+        radius = max_coord / 10
+        mesh = pv.Sphere(radius, (max_coord, max_coord, max_coord))
+        try:
+            twinmodel.project_tbrom_on_mesh(romname, mesh, False, nslist[0], radius=radius, strategy="mask_points")
+        except TwinModelError as e:
+            assert "[TbRomInterpolation]" in str(e)
+
         # Raise an exception if any issue occurs during projection
         model_filepath = download_file("ThermalTBROM_FieldInput_23R1.twin", "twin_files")
         twinmodel = TwinModel(model_filepath=model_filepath)


### PR DESCRIPTION
Exposes PyVista interpolation settings at the top level, allowing user to choose interpolation sharpness, radius, strategy (with null value) and n_points options.

In addition, if the 'mask_points' strategy is chosen, the projected mesh basis is filtered to only include cells that have valid interpolated points. This can be set to include cells where all points are valid, or cells where any point is valid. It returns an error if the filtering removes all the points from the mesh.

Closes [issue ](https://github.com/ansys/pytwin/issues/252)