### PR TITLE
Add missing doc for `snapshot_to_array` and clean up docstrings

### DIFF
--- a/doc/source/api/evaluate/index.rst
+++ b/doc/source/api/evaluate/index.rst
@@ -3,7 +3,7 @@
 Evaluate
 ========
 
-The :class:`TwinModel <ansys.pytwin.TwinModel` class implements a higher-level
+The :class:`TwinModel <pytwin.TwinModel>` class implements a higher-level
 abstraction to facilitate the manipulation and execution of a twin model. 
 
 .. currentmodule:: pytwin

--- a/doc/source/api/examples/index.rst
+++ b/doc/source/api/examples/index.rst
@@ -10,9 +10,9 @@ Other PyTwin functions are available and used in :ref:`ref_example_gallery`.
 .. autosummary::
    :toctree: _autosummary
 
-   pytwin.download_file
-   pytwin.load_data
-   pytwin.read_binary
-   pytwin.read_snapshot_size
-   pytwin.snapshot_to_array
-   pytwin.write_binary
+   download_file
+   load_data
+   read_binary
+   read_snapshot_size
+   snapshot_to_array
+   write_binary

--- a/doc/source/api/examples/index.rst
+++ b/doc/source/api/examples/index.rst
@@ -14,4 +14,5 @@ Other PyTwin functions are available and used in :ref:`ref_example_gallery`.
    pytwin.load_data
    pytwin.read_binary
    pytwin.read_snapshot_size
+   pytwin.snapshot_to_array
    pytwin.write_binary

--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -6,20 +6,20 @@ API reference
 
 This section describes the core Pythonic interfaces for twin runtimes.
 Here, you can find all APIs for consuming twin runtimes, from the lowest-level APIs
-with the :class:`ansys.pytwin.TwinRuntime` class to the higher-level
-APIs with the :class:`ansys.pytwin.TwinModel` class.
+with the :class:`pytwin.TwinRuntime` class to the higher-level
+APIs with the :class:`pytwin.TwinModel` class.
 
 Twin runtimes
 -------------
 
-The :class:`TwinRuntime <ansys.pytwin.TwinRuntime` class provides access to all
+The :class:`TwinRuntime <pytwin.TwinRuntime>` class provides access to all
 the twin runtime functionalities. It is the lowest-level API of the twin runtime SDK.
 For a workflow example, see :ref:`ref_index_api_sdk`.
 
 Evaluate
 --------
 
-The :class:`TwinModel <ansys.pytwin.TwinModel` class implements a higher-level
+The :class:`TwinModel <pytwin.TwinModel>` class implements a higher-level
 abstraction to facilitate the manipulation and execution of a twin model. For more
 information, see :ref:`ref_index_api_evaluate`.
 

--- a/doc/source/api/sdk/index.rst
+++ b/doc/source/api/sdk/index.rst
@@ -3,7 +3,7 @@
 Twin runtimes
 =============
 
-The :class:`TwinRuntime <ansys.pytwin.TwinRuntime` class provides access to
+The :class:`TwinRuntime <pytwin.TwinRuntime>` class provides access to
 twin runtime functionalities.
 
 .. currentmodule:: pytwin

--- a/src/ansys/pytwin/evaluate/twin_model.py
+++ b/src/ansys/pytwin/evaluate/twin_model.py
@@ -1261,7 +1261,7 @@ class TwinModel(Model):
         ----------
         rom_name : str
             Name of the ROM. To get a list of available ROMs, see
-            the :attr:`pytwin.TwinModel.tbrom_names' attribute.
+            the :attr:`pytwin.TwinModel.tbrom_names` attribute.
         view_name : str
             View name associated with the rendering view in which ROM results are displayed. To get
             a list of available rendering view names for a given ROM, use the

--- a/src/ansys/pytwin/settings.py
+++ b/src/ansys/pytwin/settings.py
@@ -87,7 +87,9 @@ def modify_pytwin_logging(
     new_level: PyTwinLogLevel = PyTwinLogLevel.PYTWIN_LOG_INFO,
 ):
     """
-    Modify global PyTwin logging. You can choose to take these actions:
+    Modify global PyTwin logging.
+
+    You can choose to take these actions:
 
     - Redirect logging to a log file.
     - Redirect logging to the console.

--- a/src/ansys/pytwin/twin_runtime/twin_runtime_core.py
+++ b/src/ansys/pytwin/twin_runtime/twin_runtime_core.py
@@ -205,7 +205,7 @@ class TwinRuntime:
         Returns
         -------
         int
-            Number of expected number of deployments for the TWIN model.
+            Expected number of deployments for the TWIN model.
         """
         runtime_library = TwinRuntime.load_dll()
         TwinNumberOfDeployments = runtime_library.TwinGetNumberOfDeployments
@@ -763,9 +763,10 @@ class TwinRuntime:
         ----------
         log_level : LogLevel
             Log level selected for the log file
-            (LogLevel.TWIN_LOG_ALL, LogLevel.TWIN_LOG_WARNING,
-             LogLevel.TWIN_LOG_ERROR, LogLevel.TWIN_LOG_FATAL,
-             LogLevel.TWIN_NO_LOG).
+
+                LogLevel.TWIN_LOG_ALL, LogLevel.TWIN_LOG_WARNING,
+                LogLevel.TWIN_LOG_ERROR, LogLevel.TWIN_LOG_FATAL,
+                LogLevel.TWIN_NO_LOG
         """
         # This ensures that DLL loading mechanism gets reset to its default
         # behavior, which is altered when the SDK launches in Twin Deployer.
@@ -835,6 +836,15 @@ class TwinRuntime:
     """
 
     def twin_number_of_deployments_from_instance(self):
+        """
+        Returns the expected number of deployments for the current TWIN model
+        instance as defined at the export time.
+        
+        Returns
+        -------
+        int
+            Expected number of deployments for the TWIN model instance.
+        """
         if self._is_model_opened is False:
             raise TwinRuntimeError(
                 "The model has to be opened before returning "
@@ -1870,16 +1880,21 @@ class TwinRuntime:
         str
             Information about TBROM models visualization resources included
             in the TWIN. Example of output:
-            {'myTBROM_1': {
-              'type': 'image,3D',
-              'modelname': 'myTBROM',
-              'views': {'View1': 'View1'},
-              'trigger': {
-                'field_data_storage': 'field_data_storage'
-               }
-              }
-            }
 
+            .. code-block:: python
+
+                {
+                    'myTBROM_1': {
+                        'type': 'image,3D',
+                        'modelname': 'myTBROM',
+                        'views': {
+                            'View1': 'View1'
+                            },
+                        'trigger': {
+                            'field_data_storage': 'field_data_storage'
+                            }
+                    }
+                }
         """
         visualization_info = c_char_p()
         self._twin_status = self._TwinGetVisualizationResources(


### PR DESCRIPTION
Added a missing autodoc reference to `snapshot_to_array` to the 'Other Functions' section.

Minor cleanup of docstrings to address warnings raised during Sphinx build.

Fixed cross-references to TwinModel and TwinRuntime.

Added missing docstring for `twin_number_of_deployments_from_instance`.