### PR TITLE
disabling unbutu 20.04 testing 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
        matrix:
-           os: [windows-latest, ubuntu-20.04]
+           os: [windows-latest]
            python-version: ["3.10", "3.11", "3.12"]
     steps:
       - name: Install Ubuntu dependencies for RomViewerSharedLib.so


### PR DESCRIPTION
This PR disables temporarily the package testing on Ubuntu 20.04 since the runners have been retired. Linux testing will be added back with an other PR for Ubuntu 22.04 once the Twin SDK is updated with 2025R2 version

Action error : This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101

