### PR TITLE
Fix deploy documentation permissions issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: doc-build
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write   # allow pushing to gh-pages
     steps:
       - uses: ansys/actions/doc-deploy-dev@v10.1
         with:
@@ -218,6 +220,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: release-pypi-public
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    permissions:
+      contents: write
     steps:
       - name: "Deploy the stable documentation"
         uses: ansys/actions/doc-deploy-stable@v10.1


### PR DESCRIPTION
Adding write permissions to push the documentation deployment (both for dev and public)