### PR TITLE
Adding TwinModel print_model_info

### DIFF
--- a/examples/01-twin_examples/00-coupledClutches.py
+++ b/examples/01-twin_examples/00-coupledClutches.py
@@ -112,6 +112,7 @@ def plot_result_comparison(step_by_step_results: pd.DataFrame, batch_results: pd
 
 print("Loading model: {}".format(twin_file))
 twin_model = TwinModel(twin_file)
+twin_model.print_model_info()
 twin_model_input_df = load_data(csv_input)
 data_dimensions = twin_model_input_df.shape
 number_of_datapoints = data_dimensions[0] - 1

--- a/examples/02-tbrom_examples/02-TBROM_input_field.py
+++ b/examples/02-tbrom_examples/02-TBROM_input_field.py
@@ -191,6 +191,8 @@ rom_inputs = [4000000, 5000000, 6000000]
 print("Loading model: {}".format(twin_file))
 twin_model = TwinModel(twin_file)
 
+twin_model.print_model_info()
+
 ###############################################################################
 # Evaluate the twin with different input values and collect corresponding outputs
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/02-tbrom_examples/07-TBROM_parametric_field_history.py
+++ b/examples/02-tbrom_examples/07-TBROM_parametric_field_history.py
@@ -98,6 +98,7 @@ rom_inputs = {"testROM_25r2_1_force_1_Magnitude": 9500, "testROM_25r2_1_force_2_
 
 print("Loading model: {}".format(twin_file))
 twin_model = TwinModel(twin_file)
+twin_model.print_model_info()
 romname = twin_model.tbrom_names[0]
 twin_model.initialize_evaluation(parameters=rom_inputs)
 field_data = twin_model.get_tbrom_output_field(romname)

--- a/src/ansys/pytwin/evaluate/twin_model.py
+++ b/src/ansys/pytwin/evaluate/twin_model.py
@@ -941,9 +941,7 @@ class TwinModel(Model):
         """
         return len(self.tbrom_names)
 
-    def print_model_info(
-        self, max_var_to_print=np.inf
-    ):
+    def print_model_info(self, max_var_to_print=np.inf):
         """
         Print all the model information including Twin Runtime version, model name, number of outputs, inputs,
         parameters, default simulation settings, output names, input names and parameter names. If TBROMs are present,
@@ -975,24 +973,24 @@ class TwinModel(Model):
         if self.tbrom_count > 0:
             tbroms = self.tbrom_names
             tbrom_info = self.tbrom_info
-            print('TBROMs information:')
+            print("TBROMs information:")
             for tbrom in tbroms:
                 rom_info = tbrom_info[tbrom]
-                print('Model name : {}'.format(rom_info['modelname']))
-                print('Output field name : {}'.format(self.get_field_output_name(tbrom)))
-                print('Output field connected : {}'.format(self._tbroms[tbrom]._hasoutmcs))
-                print('Has geometry/points file : {}'.format(self._tbroms[tbrom].has_point_file))
+                print("Model name : {}".format(rom_info["modelname"]))
+                print("Output field name : {}".format(self.get_field_output_name(tbrom)))
+                print("Output field connected : {}".format(self._tbroms[tbrom]._hasoutmcs))
+                print("Has geometry/points file : {}".format(self._tbroms[tbrom].has_point_file))
                 if self._tbroms[tbrom]._hasinfmcs is not None:
-                    print('Input fields : ')
+                    print("Input fields : ")
                     for key, value in self._tbroms[tbrom]._hasinfmcs.items():
-                        print('    Name : {}, Connected : {}'.format(key, value))
+                        print("    Name : {}, Connected : {}".format(key, value))
                 else:
-                    print('Has input fields : False')
-                print('Parametric Field History : {}'.format(self._tbroms[tbrom].isparamfieldhist))
-                print('Named selections : {}'.format(self.get_named_selections(tbrom)))
-                print('Product version to generate TBROM : {}\n'.format(self._tbroms[tbrom].product_version))
+                    print("Has input fields : False")
+                print("Parametric Field History : {}".format(self._tbroms[tbrom].isparamfieldhist))
+                print("Named selections : {}".format(self.get_named_selections(tbrom)))
+                print("Product version to generate TBROM : {}\n".format(self._tbroms[tbrom].product_version))
         else:
-            print('Has TBROMs : False')
+            print("Has TBROMs : False")
 
     def initialize_evaluation(
         self, parameters: dict = None, inputs: dict = None, field_inputs: dict = None, json_config_filepath: str = None

--- a/src/ansys/pytwin/evaluate/twin_model.py
+++ b/src/ansys/pytwin/evaluate/twin_model.py
@@ -975,7 +975,7 @@ class TwinModel(Model):
         if self.tbrom_count > 0:
             tbroms = self.tbrom_names
             tbrom_info = self.tbrom_info
-            print("TBROMs information:")
+            print('TBROMs information:')
             for tbrom in tbroms:
                 rom_info = tbrom_info[tbrom]
                 print('Model name : {}'.format(rom_info['modelname']))
@@ -991,6 +991,8 @@ class TwinModel(Model):
                 print('Parametric Field History : {}'.format(self._tbroms[tbrom].isparamfieldhist))
                 print('Named selections : {}'.format(self.get_named_selections(tbrom)))
                 print('Product version to generate TBROM : {}\n'.format(self._tbroms[tbrom].product_version))
+        else:
+            print('Has TBROMs : False')
 
     def initialize_evaluation(
         self, parameters: dict = None, inputs: dict = None, field_inputs: dict = None, json_config_filepath: str = None

--- a/src/ansys/pytwin/evaluate/twin_model.py
+++ b/src/ansys/pytwin/evaluate/twin_model.py
@@ -941,6 +941,57 @@ class TwinModel(Model):
         """
         return len(self.tbrom_names)
 
+    def print_model_info(
+        self, max_var_to_print=np.inf
+    ):
+        """
+        Print all the model information including Twin Runtime version, model name, number of outputs, inputs,
+        parameters, default simulation settings, output names, input names and parameter names. If TBROMs are present,
+        it will also print associated information.
+
+        This method must be called a TwinModel has been instantiated.
+
+
+        .. note::
+            if field inputs are supplied for a TBROM, they will override any input mode coefficient inputs for
+            that ROM that are included in ``inputs``.
+
+        Parameters
+        ----------
+        max_var_to_print : int, optional
+            Maximum number of variables for which the properties need to be evaluated, default value is numpy.inf.
+
+        Examples
+        --------
+        >>> from pytwin import TwinModel
+        >>>
+        >>> twin_model = TwinModel(model_filepath='path_to_your_twin_model.twin')
+        >>> twin_model.print_model_info()
+        """
+        self._log_key = "PrintModelInfo"
+
+        self._twin_runtime.print_model_info(max_var_to_print)
+
+        if self.tbrom_count > 0:
+            tbroms = self.tbrom_names
+            tbrom_info = self.tbrom_info
+            print("TBROMs information:")
+            for tbrom in tbroms:
+                rom_info = tbrom_info[tbrom]
+                print('Model name : {}'.format(rom_info['modelname']))
+                print('Output field name : {}'.format(self.get_field_output_name(tbrom)))
+                print('Output field connected : {}'.format(self._tbroms[tbrom]._hasoutmcs))
+                print('Has geometry/points file : {}'.format(self._tbroms[tbrom].has_point_file))
+                if self._tbroms[tbrom]._hasinfmcs is not None:
+                    print('Input fields : ')
+                    for key, value in self._tbroms[tbrom]._hasinfmcs.items():
+                        print('    Name : {}, Connected : {}'.format(key, value))
+                else:
+                    print('Has input fields : False')
+                print('Parametric Field History : {}'.format(self._tbroms[tbrom].isparamfieldhist))
+                print('Named selections : {}'.format(self.get_named_selections(tbrom)))
+                print('Product version to generate TBROM : {}\n'.format(self._tbroms[tbrom].product_version))
+
     def initialize_evaluation(
         self, parameters: dict = None, inputs: dict = None, field_inputs: dict = None, json_config_filepath: str = None
     ):

--- a/src/ansys/pytwin/evaluate/twin_model.py
+++ b/src/ansys/pytwin/evaluate/twin_model.py
@@ -947,7 +947,7 @@ class TwinModel(Model):
         parameters, default simulation settings, output names, input names and parameter names. If TBROMs are present,
         it will also print associated information.
 
-        This method must be called a TwinModel has been instantiated.
+        This method must be called after a TwinModel has been instantiated.
 
 
         .. note::

--- a/tests/evaluate/test_tbrom.py
+++ b/tests/evaluate/test_tbrom.py
@@ -1502,3 +1502,47 @@ class TestTbRom:
             assert np.isclose(maxt100, 1.685669230751107)
             assert np.isclose(maxt250, 5.635884051349383)
         assert np.isclose(maxt250, maxt300)
+
+    def test_print_model_info(self):
+        import io
+        from contextlib import redirect_stdout
+
+        model_filepath = COUPLE_CLUTCHES_FILEPATH
+        twinmodel = TwinModel(model_filepath=model_filepath)
+        f = io.StringIO()
+        with redirect_stdout(f):
+            twinmodel.print_model_info()
+        output = f.getvalue()
+        assert 'Has TBROMs : False' in output
+        twinmodel.close()
+
+        model_filepath = TEST_TB_ROM2
+        twinmodel = TwinModel(model_filepath=model_filepath)
+        f = io.StringIO()
+        with redirect_stdout(f):
+            twinmodel.print_model_info()
+        output = f.getvalue()
+        assert 'Output field connected : False' in output
+        assert 'Has input fields : False' not in output
+        twinmodel.close()
+
+        model_filepath = TEST_TB_ROM3
+        twinmodel = TwinModel(model_filepath=model_filepath)
+        f = io.StringIO()
+        with redirect_stdout(f):
+            twinmodel.print_model_info()
+        output = f.getvalue()
+        assert 'Output field connected : True' in output
+        assert ', Connected : True' in output
+        twinmodel.close()
+
+        model_filepath = TEST_TB_PFIELD_HISTORY
+        twinmodel = TwinModel(model_filepath=model_filepath)
+        f = io.StringIO()
+        with redirect_stdout(f):
+            twinmodel.print_model_info()
+        output = f.getvalue()
+        assert 'Parametric Field History : True' in output
+        twinmodel.close()
+
+

--- a/tests/evaluate/test_tbrom.py
+++ b/tests/evaluate/test_tbrom.py
@@ -1504,8 +1504,8 @@ class TestTbRom:
         assert np.isclose(maxt250, maxt300)
 
     def test_print_model_info(self):
-        import io
         from contextlib import redirect_stdout
+        import io
 
         model_filepath = COUPLE_CLUTCHES_FILEPATH
         twinmodel = TwinModel(model_filepath=model_filepath)
@@ -1513,7 +1513,7 @@ class TestTbRom:
         with redirect_stdout(f):
             twinmodel.print_model_info()
         output = f.getvalue()
-        assert 'Has TBROMs : False' in output
+        assert "Has TBROMs : False" in output
         twinmodel.close()
 
         model_filepath = TEST_TB_ROM2
@@ -1522,8 +1522,8 @@ class TestTbRom:
         with redirect_stdout(f):
             twinmodel.print_model_info()
         output = f.getvalue()
-        assert 'Output field connected : False' in output
-        assert 'Has input fields : False' not in output
+        assert "Output field connected : False" in output
+        assert "Has input fields : False" not in output
         twinmodel.close()
 
         model_filepath = TEST_TB_ROM3
@@ -1532,8 +1532,8 @@ class TestTbRom:
         with redirect_stdout(f):
             twinmodel.print_model_info()
         output = f.getvalue()
-        assert 'Output field connected : True' in output
-        assert ', Connected : True' in output
+        assert "Output field connected : True" in output
+        assert ", Connected : True" in output
         twinmodel.close()
 
         model_filepath = TEST_TB_PFIELD_HISTORY
@@ -1542,7 +1542,5 @@ class TestTbRom:
         with redirect_stdout(f):
             twinmodel.print_model_info()
         output = f.getvalue()
-        assert 'Parametric Field History : True' in output
+        assert "Parametric Field History : True" in output
         twinmodel.close()
-
-


### PR DESCRIPTION
This function expose the twin_runtime.print_model_info, and in case the Twin includes TBROMs, it will output additional information related to the TBROMs

This implements the suggestion of #131 