### PR TITLE
feat: update license headers to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+Copyright (c) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/examples/00-twin_creation/00-TBROM_Twin_creation_evaluation.py
+++ b/examples/00-twin_creation/00-TBROM_Twin_creation_evaluation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/01-twin_examples/00-coupledClutches.py
+++ b/examples/01-twin_examples/00-coupledClutches.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/01-twin_examples/01-electricRange.py
+++ b/examples/01-twin_examples/01-electricRange.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/01-twin_examples/02-heatExchangerRS.py
+++ b/examples/01-twin_examples/02-heatExchangerRS.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/01-twin_examples/03-scalarDROM.py
+++ b/examples/01-twin_examples/03-scalarDROM.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/02-tbrom_examples/00-TBROM_images.py
+++ b/examples/02-tbrom_examples/00-TBROM_images.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/02-tbrom_examples/01-TBROM_dataTransfer_pyMAPDL.py
+++ b/examples/02-tbrom_examples/01-TBROM_dataTransfer_pyMAPDL.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/02-tbrom_examples/02-TBROM_input_field.py
+++ b/examples/02-tbrom_examples/02-TBROM_input_field.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/02-tbrom_examples/03-TBROM_input_numpy_field.py
+++ b/examples/02-tbrom_examples/03-TBROM_input_numpy_field.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/02-tbrom_examples/04-TBROM_CFD_mesh_based_visualization.py
+++ b/examples/02-tbrom_examples/04-TBROM_CFD_mesh_based_visualization.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/02-tbrom_examples/05-TBROM_FEA_mesh_based_visualization.py
+++ b/examples/02-tbrom_examples/05-TBROM_FEA_mesh_based_visualization.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/02-tbrom_examples/06-TBROM_FEA_static_structural_optimization.py
+++ b/examples/02-tbrom_examples/06-TBROM_FEA_static_structural_optimization.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/02-tbrom_examples/07-TBROM_parametric_field_history.py
+++ b/examples/02-tbrom_examples/07-TBROM_parametric_field_history.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/pytwin/__init__.py
+++ b/src/ansys/pytwin/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/pytwin/decorators.py
+++ b/src/ansys/pytwin/decorators.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/pytwin/evaluate/__init__.py
+++ b/src/ansys/pytwin/evaluate/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/pytwin/evaluate/model.py
+++ b/src/ansys/pytwin/evaluate/model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/pytwin/evaluate/saved_state_registry.py
+++ b/src/ansys/pytwin/evaluate/saved_state_registry.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/pytwin/evaluate/tbrom.py
+++ b/src/ansys/pytwin/evaluate/tbrom.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/pytwin/evaluate/twin_model.py
+++ b/src/ansys/pytwin/evaluate/twin_model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/pytwin/examples/__init__.py
+++ b/src/ansys/pytwin/examples/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/pytwin/examples/downloads.py
+++ b/src/ansys/pytwin/examples/downloads.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/pytwin/postprocessing/__init__.py
+++ b/src/ansys/pytwin/postprocessing/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/pytwin/postprocessing/postprocessing.py
+++ b/src/ansys/pytwin/postprocessing/postprocessing.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/pytwin/settings.py
+++ b/src/ansys/pytwin/settings.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/pytwin/twin_runtime/log_level.py
+++ b/src/ansys/pytwin/twin_runtime/log_level.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/pytwin/twin_runtime/twin_runtime_core.py
+++ b/src/ansys/pytwin/twin_runtime/twin_runtime_core.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/pytwin/twin_runtime/twin_runtime_error.py
+++ b/src/ansys/pytwin/twin_runtime/twin_runtime_error.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/evaluate/__init__.py
+++ b/tests/evaluate/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/evaluate/test_model.py
+++ b/tests/evaluate/test_model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/evaluate/test_savedstate_registry.py
+++ b/tests/evaluate/test_savedstate_registry.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/evaluate/test_tbrom.py
+++ b/tests/evaluate/test_tbrom.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/evaluate/test_twin_model.py
+++ b/tests/evaluate/test_twin_model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/evaluate/test_twin_model_finalizer.py
+++ b/tests/evaluate/test_twin_model_finalizer.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/evaluate/test_twin_model_logging.py
+++ b/tests/evaluate/test_twin_model_logging.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/examples/__init__.py
+++ b/tests/examples/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/examples/test_downloads.py
+++ b/tests/examples/test_downloads.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/postprocessing/test_postprocessing.py
+++ b/tests/postprocessing/test_postprocessing.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/twin_runtime/__init__.py
+++ b/tests/twin_runtime/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/twin_runtime/test_twin_runtime_core.py
+++ b/tests/twin_runtime/test_twin_runtime_core.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/twin_runtime/test_twin_runtime_error.py
+++ b/tests/twin_runtime/test_twin_runtime_error.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #


### PR DESCRIPTION
Update the license headers of the project to the new year 2026. Related with https://github.com/ansys/actions/pull/1102