### PR TITLE
Update conf.py to skip Sphinx Gallery execution of tagged examples

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -115,8 +115,8 @@ sphinx_gallery_conf = {
     "examples_dirs": ["../../examples/"],
     # path where to save gallery generated examples
     "gallery_dirs": ["examples"],
-    # Pattern to search for example files
-    "filename_pattern": r"\.py",
+    # Pattern to search for example files. Match all .py, except those ending with "_no_execute.py".
+    "filename_pattern": r"(?<!_no_execute)\.py",
     # Remove the "Download all examples" button from the top level gallery
     "download_all_examples": False,
     # Sort gallery example by file name instead of number of lines (default)


### PR DESCRIPTION
This change allows Sphinx Gallery to process certain Python files without executing them while building the doc. This is anticipation of future examples, like GUI app demonstrators, that should be parsed for documentation, but not run as notebooks.

Any Python file named *_no_execute.py will be parsed and added, but not executed per: https://sphinx-gallery.github.io/stable/configuration.html#parsing-and-executing-examples-via-matching-patterns.

This should not change the doc build behaviour for existing files.