### PR TITLE
[FEAT] extend projection methods to keep track of multiple named selections

### DIFF
--- a/src/ansys/pytwin/evaluate/tbrom.py
+++ b/src/ansys/pytwin/evaluate/tbrom.py
@@ -555,11 +555,13 @@ class TbRom:
             nb_data = self._outmeshbasis[named_selection].shape[1]
             mesh_data[self.field_output_name] = np.zeros((nb_data, self.field_output_dim))
             self._meshdata[named_selection] = mesh_data
+            return self._meshdata[named_selection]
+
         else:
             nb_data = self._outmeshbasis.shape[1]
             mesh_data[self.field_output_name] = np.zeros((nb_data, self.field_output_dim))
             self._meshdata = mesh_data
-        return self._meshdata
+            return self._meshdata
 
     def _update_output_field(self, time=None):
         """

--- a/src/ansys/pytwin/evaluate/tbrom.py
+++ b/src/ansys/pytwin/evaluate/tbrom.py
@@ -646,9 +646,9 @@ class TbRom:
             ) * (self._outbasis[:, index, :, :] - self._outbasis[:, index - 1, :, :])
 
         if self._meshdata:
-            if len(self.named_selections) > 0:
+            if isinstance(self._meshdata, dict):
                 meshgrid = dict()
-                for ns in self.named_selections:
+                for ns in self._meshdata:
                     if time <= timegrid[0] or time >= timegrid[-1]:
                         meshgrid[ns] = self._meshdata[ns][index]
                     else:
@@ -750,10 +750,10 @@ class TbRom:
                             minValue,
                             maxValue,
                         )
-            else:
-                self._meshdata[self.field_output_name] = np.clip(
-                    np.power(np.exp(self._meshdata[self.field_output_name]) + alpha, -1) + beta, minValue, maxValue
-                )
+                else:
+                    self._meshdata[self.field_output_name] = np.clip(
+                        np.power(np.exp(self._meshdata[self.field_output_name]) + alpha, -1) + beta, minValue, maxValue
+                    )
 
     def _clean_log(self):
         self._logLevel = None

--- a/src/ansys/pytwin/evaluate/tbrom.py
+++ b/src/ansys/pytwin/evaluate/tbrom.py
@@ -562,7 +562,7 @@ class TbRom:
             if not self.isparamfieldhist:
                 self._meshdata[self.field_output_name] = np.tensordot(mc, self._outmeshbasis, axes=1)
             else:
-                self._pointsdata[self.field_output_name] = np.tensordot(mc, outmeshbasis, axes=1)
+                self._meshdata[self.field_output_name] = np.tensordot(mc, outmeshbasis, axes=1)
             if self.field_output_dim > 1:
                 update_vector_norm(self._meshdata, self.field_output_name)
             self._meshdata.set_active_scalars(self.field_output_name)

--- a/src/ansys/pytwin/evaluate/tbrom.py
+++ b/src/ansys/pytwin/evaluate/tbrom.py
@@ -284,9 +284,7 @@ class TbRom:
         self._outmcs = None
         self._infbasis = None
         self._pointsdata = None
-        self._meshdata = None
         self._outbasis = None
-        self._outmeshbasis = None
         self._hasinfmcs = None
         self._hasoutmcs = False
         self._productVersion = None
@@ -325,6 +323,13 @@ class TbRom:
         self._infbasis = infdata
 
         self._nsidslist = nsidslist
+        if self._nsidslist: # multiple named selections -> initialize _meshdata and _outmeshbasis 
+            # as dict to track each named selection 
+            self._meshdata = dict()
+            self._outmeshbasis = dict()
+        else:
+            self._meshdata = None
+            self._outmeshbasis = None
         self._outdim = int(dimensionality[0])
         self._outname = outputname
         self._outunit = unit
@@ -494,7 +499,9 @@ class TbRom:
                 pointsids = self._named_selection_indexes(named_selection)
                 listids = np.sort(pointsids)
                 outmeshbasis = outmeshbasis[:, listids]
-            self._outmeshbasis = outmeshbasis
+                self._outmeshbasis[named_selection] = outmeshbasis
+            else:
+                self._outmeshbasis = outmeshbasis
         else:  # interpolation required, e.g. because target mesh is different
             progress_bar = False
             if _HAS_TQDM:
@@ -525,10 +532,16 @@ class TbRom:
                     )
             if not nodal_values:
                 interpolated_mesh = interpolated_points.point_data_to_cell_data()
-                self._outmeshbasis = np.array([interpolated_mesh.cell_data[str(i)] for i in range(0, nbmc)])
+                if named_selection is not None:
+                    self._outmeshbasis[named_selection] = np.array([interpolated_mesh.cell_data[str(i)] for i in range(0, nbmc)])
+                else:
+                    self._outmeshbasis = np.array([interpolated_mesh.cell_data[str(i)] for i in range(0, nbmc)])
             else:
                 interpolated_mesh = interpolated_points
-                self._outmeshbasis = np.array([interpolated_mesh.point_data[str(i)] for i in range(0, nbmc)])
+                if named_selection is not None:
+                    self._outmeshbasis[named_selection] = np.array([interpolated_mesh.point_data[str(i)] for i in range(0, nbmc)])
+                else:
+                    self._outmeshbasis = np.array([interpolated_mesh.point_data[str(i)] for i in range(0, nbmc)])
 
         if interpolate and strategy == "mask_points":
             mesh_data = interpolated_mesh.copy()
@@ -538,10 +551,15 @@ class TbRom:
         mesh_data.clear_data()
 
         # initialize output field data
-        nb_data = self._outmeshbasis.shape[1]
-        mesh_data[self.field_output_name] = np.zeros((nb_data, self.field_output_dim))
-
-        self._meshdata = mesh_data
+        if named_selection is not None:
+            nb_data = self._outmeshbasis[named_selection].shape[1]
+            mesh_data[self.field_output_name] = np.zeros((nb_data, self.field_output_dim))
+            self._meshdata[named_selection] = mesh_data
+        else:
+            nb_data = self._outmeshbasis.shape[1]
+            mesh_data[self.field_output_name] = np.zeros((nb_data, self.field_output_dim))
+            self._meshdata = mesh_data
+        return self._meshdata
 
     def _update_output_field(self, time=None):
         """
@@ -558,14 +576,24 @@ class TbRom:
             update_vector_norm(self._pointsdata, self.field_output_name)
         self._pointsdata.set_active_scalars(self.field_output_name)
 
-        if self._meshdata is not None:
-            if not self.isparamfieldhist:
-                self._meshdata[self.field_output_name] = np.tensordot(mc, self._outmeshbasis, axes=1)
+        if self._meshdata: # not none or empty dict (i.e. after _pojrect_on_mesh has been called)
+            if isinstance(self._meshdata, dict):
+                for ns in self._meshdata:
+                    if not self.isparamfieldhist:
+                        self._meshdata[ns][self.field_output_name] = np.tensordot(mc, self._outmeshbasis[ns], axes=1)
+                    else:
+                        self._meshdata[ns][self.field_output_name] = np.tensordot(mc, outmeshbasis[ns], axes=1)
+                    if self.field_output_dim > 1:
+                        update_vector_norm(self._meshdata[ns], self.field_output_name)
+                    self._meshdata[ns].set_active_scalars(self.field_output_name)
             else:
-                self._meshdata[self.field_output_name] = np.tensordot(mc, outmeshbasis, axes=1)
-            if self.field_output_dim > 1:
-                update_vector_norm(self._meshdata, self.field_output_name)
-            self._meshdata.set_active_scalars(self.field_output_name)
+                if not self.isparamfieldhist:
+                    self._meshdata[self.field_output_name] = np.tensordot(mc, self._outmeshbasis, axes=1)
+                else:
+                    self._meshdata[self.field_output_name] = np.tensordot(mc, outmeshbasis, axes=1)
+                if self.field_output_dim > 1:
+                    update_vector_norm(self._meshdata, self.field_output_name)
+                self._meshdata.set_active_scalars(self.field_output_name)
 
         if self._transformation is not None:
             self._reverseConstraints()
@@ -611,13 +639,23 @@ class TbRom:
                 timegrid[index] - timegrid[index - 1]
             ) * (self._outbasis[:, index, :, :] - self._outbasis[:, index - 1, :, :])
 
-        if self._meshdata is not None:
-            if time <= timegrid[0] or time >= timegrid[-1]:
-                meshgrid = self._meshdata[index]
+        if self._meshdata:
+            if len(self.named_selections) > 0:
+                meshgrid = dict()
+                for ns in self.named_selections:
+                    if time <= timegrid[0] or time >= timegrid[-1]:
+                        meshgrid[ns] = self._meshdata[ns][index]
+                    else:
+                        meshgrid[ns] = self._meshdata[ns][:, index - 1, :, :] + (time - timegrid[index - 1]) / (
+                            timegrid[index] - timegrid[index - 1]
+                        ) * (self._meshdata[ns][:, index, :, :] - self._meshdata[ns][:, index - 1, :, :])
             else:
-                meshgrid = self._meshdata[:, index - 1, :, :] + (time - timegrid[index - 1]) / (
-                    timegrid[index] - timegrid[index - 1]
-                ) * (self._meshdata[:, index, :, :] - self._meshdata[:, index - 1, :, :])
+                if time <= timegrid[0] or time >= timegrid[-1]:
+                    meshgrid = self._meshdata[index]
+                else:
+                    meshgrid = self._meshdata[:, index - 1, :, :] + (time - timegrid[index - 1]) / (
+                        timegrid[index] - timegrid[index - 1]
+                    ) * (self._meshdata[:, index, :, :] - self._meshdata[:, index - 1, :, :])
 
         return outgrid, meshgrid
 
@@ -657,15 +695,23 @@ class TbRom:
             minValue = self._transformation["minValue"]
             self._pointsdata[self.field_output_name] = np.power(self._pointsdata[self.field_output_name], 2) + minValue
 
-            if self._meshdata is not None:
-                self._meshdata[self.field_output_name] = np.power(self._meshdata[self.field_output_name], 2) + minValue
+            if self._meshdata:
+                if isinstance(self._meshdata, dict):
+                    for ns in self._meshdata:
+                        self._meshdata[ns][self.field_output_name] = np.power(self._meshdata[ns][self.field_output_name], 2) + minValue
+                else:
+                    self._meshdata[self.field_output_name] = np.power(self._meshdata[self.field_output_name], 2) + minValue
 
         elif self._transformation["function"] == "max":
             maxValue = self._transformation["maxValue"]
             self._pointsdata[self.field_output_name] = maxValue - np.power(self._pointsdata[self.field_output_name], 2)
 
-            if self._meshdata is not None:
-                self._meshdata[self.field_output_name] = maxValue - np.power(self._meshdata[self.field_output_name], 2)
+            if self._meshdata:
+                if isinstance(self._meshdata, dict):
+                    for ns in self._meshdata:
+                        self._meshdata[ns][self.field_output_name] = maxValue - np.power(self._meshdata[ns][self.field_output_name], 2)
+                else:
+                    self._meshdata[self.field_output_name] = maxValue - np.power(self._meshdata[self.field_output_name], 2)
 
         elif self._transformation["function"] == "minMax":
             minValue = self._transformation["minValue"]
@@ -682,7 +728,13 @@ class TbRom:
                 np.power(np.exp(self._pointsdata[self.field_output_name]) + alpha, -1) + beta, minValue, maxValue
             )
 
-            if self._meshdata is not None:
+            if self._meshdata:
+                if isinstance(self._meshdata, dict):
+                    for ns in self._meshdata:
+                        self._meshdata[ns][self.field_output_name] = np.clip(
+                            np.power(np.exp(self._meshdata[ns][self.field_output_name]) + alpha, -1) + beta, minValue, maxValue
+                        )
+            else:
                 self._meshdata[self.field_output_name] = np.clip(
                     np.power(np.exp(self._meshdata[self.field_output_name]) + alpha, -1) + beta, minValue, maxValue
                 )

--- a/src/ansys/pytwin/evaluate/tbrom.py
+++ b/src/ansys/pytwin/evaluate/tbrom.py
@@ -499,7 +499,7 @@ class TbRom:
                     self._meshdata = None
                     self._outmeshbasis = None
             else:  # pv.DataSet
-                if named_selection is not None:  # naamed selection -> reset to dict case
+                if named_selection is not None:  # named selection -> reset to dict case
                     self._meshdata = dict()
                     self._outmeshbasis = dict()
         nbmc = self.nb_modes

--- a/src/ansys/pytwin/evaluate/tbrom.py
+++ b/src/ansys/pytwin/evaluate/tbrom.py
@@ -323,8 +323,8 @@ class TbRom:
         self._infbasis = infdata
 
         self._nsidslist = nsidslist
-        if self._nsidslist: # multiple named selections -> initialize _meshdata and _outmeshbasis 
-            # as dict to track each named selection 
+        if self._nsidslist:  # multiple named selections -> initialize _meshdata and _outmeshbasis
+            # as dict to track each named selection
             self._meshdata = dict()
             self._outmeshbasis = dict()
         else:
@@ -533,13 +533,17 @@ class TbRom:
             if not nodal_values:
                 interpolated_mesh = interpolated_points.point_data_to_cell_data()
                 if named_selection is not None:
-                    self._outmeshbasis[named_selection] = np.array([interpolated_mesh.cell_data[str(i)] for i in range(0, nbmc)])
+                    self._outmeshbasis[named_selection] = np.array(
+                        [interpolated_mesh.cell_data[str(i)] for i in range(0, nbmc)]
+                    )
                 else:
                     self._outmeshbasis = np.array([interpolated_mesh.cell_data[str(i)] for i in range(0, nbmc)])
             else:
                 interpolated_mesh = interpolated_points
                 if named_selection is not None:
-                    self._outmeshbasis[named_selection] = np.array([interpolated_mesh.point_data[str(i)] for i in range(0, nbmc)])
+                    self._outmeshbasis[named_selection] = np.array(
+                        [interpolated_mesh.point_data[str(i)] for i in range(0, nbmc)]
+                    )
                 else:
                     self._outmeshbasis = np.array([interpolated_mesh.point_data[str(i)] for i in range(0, nbmc)])
 
@@ -578,7 +582,7 @@ class TbRom:
             update_vector_norm(self._pointsdata, self.field_output_name)
         self._pointsdata.set_active_scalars(self.field_output_name)
 
-        if self._meshdata: # not none or empty dict (i.e. after _pojrect_on_mesh has been called)
+        if self._meshdata:  # not none or empty dict (i.e. after _pojrect_on_mesh has been called)
             if isinstance(self._meshdata, dict):
                 for ns in self._meshdata:
                     if not self.isparamfieldhist:
@@ -700,9 +704,13 @@ class TbRom:
             if self._meshdata:
                 if isinstance(self._meshdata, dict):
                     for ns in self._meshdata:
-                        self._meshdata[ns][self.field_output_name] = np.power(self._meshdata[ns][self.field_output_name], 2) + minValue
+                        self._meshdata[ns][self.field_output_name] = (
+                            np.power(self._meshdata[ns][self.field_output_name], 2) + minValue
+                        )
                 else:
-                    self._meshdata[self.field_output_name] = np.power(self._meshdata[self.field_output_name], 2) + minValue
+                    self._meshdata[self.field_output_name] = (
+                        np.power(self._meshdata[self.field_output_name], 2) + minValue
+                    )
 
         elif self._transformation["function"] == "max":
             maxValue = self._transformation["maxValue"]
@@ -711,9 +719,13 @@ class TbRom:
             if self._meshdata:
                 if isinstance(self._meshdata, dict):
                     for ns in self._meshdata:
-                        self._meshdata[ns][self.field_output_name] = maxValue - np.power(self._meshdata[ns][self.field_output_name], 2)
+                        self._meshdata[ns][self.field_output_name] = maxValue - np.power(
+                            self._meshdata[ns][self.field_output_name], 2
+                        )
                 else:
-                    self._meshdata[self.field_output_name] = maxValue - np.power(self._meshdata[self.field_output_name], 2)
+                    self._meshdata[self.field_output_name] = maxValue - np.power(
+                        self._meshdata[self.field_output_name], 2
+                    )
 
         elif self._transformation["function"] == "minMax":
             minValue = self._transformation["minValue"]
@@ -734,7 +746,9 @@ class TbRom:
                 if isinstance(self._meshdata, dict):
                     for ns in self._meshdata:
                         self._meshdata[ns][self.field_output_name] = np.clip(
-                            np.power(np.exp(self._meshdata[ns][self.field_output_name]) + alpha, -1) + beta, minValue, maxValue
+                            np.power(np.exp(self._meshdata[ns][self.field_output_name]) + alpha, -1) + beta,
+                            minValue,
+                            maxValue,
                         )
             else:
                 self._meshdata[self.field_output_name] = np.clip(

--- a/src/ansys/pytwin/evaluate/tbrom.py
+++ b/src/ansys/pytwin/evaluate/tbrom.py
@@ -494,12 +494,12 @@ class TbRom:
         """
         # reset the attributes if needed
         if self._meshdata:  # not none or empty dict (i.e. after _pojrect_on_mesh has been called)
-            if isinstance(self._meshdata, dict): # dict case
-                if named_selection is None: # no named selection -> reset to non dict case
+            if isinstance(self._meshdata, dict):  # dict case
+                if named_selection is None:  # no named selection -> reset to non dict case
                     self._meshdata = None
                     self._outmeshbasis = None
-            else: # pv.DataSet
-                if named_selection is not None: # naamed selection -> reset to dict case
+            else:  # pv.DataSet
+                if named_selection is not None:  # naamed selection -> reset to dict case
                     self._meshdata = dict()
                     self._outmeshbasis = dict()
         nbmc = self.nb_modes

--- a/src/ansys/pytwin/evaluate/tbrom.py
+++ b/src/ansys/pytwin/evaluate/tbrom.py
@@ -492,6 +492,16 @@ class TbRom:
         pyvista.DataSetFilters.interpolate :
             Detailed description of ``sharpness``, ``radius``, ``strategy``, ``null_value`` and ``n_points`` parameters.
         """
+        # reset the attributes if needed
+        if self._meshdata:  # not none or empty dict (i.e. after _pojrect_on_mesh has been called)
+            if isinstance(self._meshdata, dict): # dict case
+                if named_selection is None: # no named selection -> reset to non dict case
+                    self._meshdata = None
+                    self._outmeshbasis = None
+            else: # pv.DataSet
+                if named_selection is not None: # naamed selection -> reset to dict case
+                    self._meshdata = dict()
+                    self._outmeshbasis = dict()
         nbmc = self.nb_modes
         if not interpolate:  # target mesh is same as the one used to generate the ROM -> no interpolation required
             outmeshbasis = self._outbasis

--- a/src/ansys/pytwin/evaluate/twin_model.py
+++ b/src/ansys/pytwin/evaluate/twin_model.py
@@ -445,6 +445,12 @@ class TwinModel(Model):
         msg = f"[ParametricFieldHistory]The given ROM name ({rom_name}) is "
         msg += f"not a parametric field history ROM."
         return msg
+    
+    def _error_msg_for_not_projection(self, rom_name):
+        msg = f"[NoProjection]The provided ROM name ({rom_name}) does not have mesh data available yet."
+        msg += f" Call this method after having projected the TBROM output field on mesh with "
+        msg += f"the method project_tbrom_output_on_mesh()."
+        return msg
 
     def _create_dataframe_inputs(self, inputs_df: pd.DataFrame):
         """
@@ -2075,7 +2081,7 @@ class TwinModel(Model):
                     interpolate_flag = interpolate
                 if interpolate_flag:
                     self._check_tbrom_points_file(rom_name)
-                self._tbroms[rom_name]._project_on_mesh(
+                meshdata = self._tbroms[rom_name]._project_on_mesh(
                     target_mesh,
                     interpolate_flag,
                     named_selection,
@@ -2088,7 +2094,7 @@ class TwinModel(Model):
                     all_points=all_points,
                 )
                 self._update_tbrom_outmcs(self._tbroms[rom_name])
-                return self._tbroms[rom_name].field_on_mesh
+                return meshdata
 
         except Exception as e:
             msg = f"Something went wrong while projecting on target mesh:"
@@ -2148,6 +2154,85 @@ class TwinModel(Model):
             raise self._raise_error(msg)
 
         return tbrom.field_on_points
+    
+    def get_tbrom_output_field_on_mesh(self, rom_name: str):
+        """
+        Return the TBROM output field projected on the target mesh, as a PyVista DataSet object or a
+        dictionary of PyVista DataSet objects (one per named selection). The resulting field is based on
+        current states of the TwinModel and is automatically updated whenever the TwinModel is evaluated.
+
+        .. note::
+            :func:`pytwin.TwinModel.project_tbrom_on_mesh` must be called before this method.
+
+        Parameters
+        ----------
+        rom_name : str
+            Name of the ROM. To get a list of available ROMs, see the
+            :attr:`pytwin.TwinModel.tbrom_names` attribute.
+
+        Returns
+        -------
+        pyvista.DataSet
+            If :func:`pytwin.TwinModel.project_tbrom_on_mesh` was previously called without a named
+            selection, returns the PyVista DataSet of the full-domain projection.
+        dict[str, pyvista.DataSet]
+            If :func:`pytwin.TwinModel.project_tbrom_on_mesh` was previously called with named selections 
+            (once or multiple times), returns a dictionary mapping each projected named selection name 
+            to its PyVista DataSet.
+
+
+        Raises
+        ------
+        TwinModelError:
+            If ``TwinModel`` object does not include any TBROMs.
+            If the provided ROM name is not available.
+            If :func:`pytwin.TwinModel.project_tbrom_on_mesh` has not been called yet for this TBROM.
+            If TBROM hasn't its mode coefficients outputs connected to the twin's outputs.
+
+        Examples
+        --------
+        >>> from pytwin import TwinModel
+        >>> import pyvista as pv
+        >>> # Example 1 - Full-domain projection (no named selection)
+        >>> model = TwinModel(model_filepath='path_to_twin_model_with_TBROM_in_it.twin')
+        >>> model.initialize_evaluation()
+        >>> romname = model.tbrom_names[0]
+        >>> target_mesh = pv.read('mesh.vtk')
+        >>> model.project_tbrom_on_mesh(romname, target_mesh, interpolate=True)
+        >>> rom_results_on_mesh = model.get_tbrom_output_field_on_mesh(romname)
+        >>> # rom_results_on_mesh is a pyvista.DataSet
+        >>> # Example 2 - Named-selection projection
+        >>> model = TwinModel(model_filepath='path_to_twin_model_with_TBROM_in_it.twin')
+        >>> model.initialize_evaluation()
+        >>> romname = model.tbrom_names[0]
+        >>> nslist = model.get_named_selections(romname)
+        >>> target_mesh = pv.read('mesh.vtk')
+        >>> for ns in nslist:
+        >>>     model.project_tbrom_on_mesh(romname, target_mesh, interpolate=True, named_selection=ns)
+        >>> rom_results_on_mesh = model.get_tbrom_output_field_on_mesh(romname)
+        >>> # rom_results_on_mesh is a dict: {ns_name: pyvista.DataSet}
+        """
+        self._log_key = "GetMeshData"
+
+        if self.tbrom_info is None:
+            msg = self._error_msg_no_tbrom()
+            self._raise_error(msg)
+
+        if rom_name not in self.tbrom_names:
+            msg = self._error_msg_for_rom_name(rom_name)
+            self._raise_error(msg)
+
+        tbrom = self._tbroms[rom_name]
+
+        if not tbrom._meshdata:
+            msg = self._error_msg_for_not_projection(rom_name)
+            self._raise_error(msg)
+
+        if not tbrom._hasoutmcs:
+            msg = self._error_msg_for_rom_output_connection(rom_name)
+            raise self._raise_error(msg)
+
+        return tbrom.field_on_mesh
 
     def get_tbrom_time_grid(self, rom_name: str):
         """

--- a/src/ansys/pytwin/evaluate/twin_model.py
+++ b/src/ansys/pytwin/evaluate/twin_model.py
@@ -445,7 +445,7 @@ class TwinModel(Model):
         msg = f"[ParametricFieldHistory]The given ROM name ({rom_name}) is "
         msg += f"not a parametric field history ROM."
         return msg
-    
+
     def _error_msg_for_not_projection(self, rom_name):
         msg = f"[NoProjection]The provided ROM name ({rom_name}) does not have mesh data available yet."
         msg += f" Call this method after having projected the TBROM output field on mesh with "
@@ -2154,7 +2154,7 @@ class TwinModel(Model):
             raise self._raise_error(msg)
 
         return tbrom.field_on_points
-    
+
     def get_tbrom_output_field_on_mesh(self, rom_name: str):
         """
         Return the TBROM output field projected on the target mesh, as a PyVista DataSet object or a
@@ -2176,8 +2176,8 @@ class TwinModel(Model):
             If :func:`pytwin.TwinModel.project_tbrom_on_mesh` was previously called without a named
             selection, returns the PyVista DataSet of the full-domain projection.
         dict[str, pyvista.DataSet]
-            If :func:`pytwin.TwinModel.project_tbrom_on_mesh` was previously called with named selections 
-            (once or multiple times), returns a dictionary mapping each projected named selection name 
+            If :func:`pytwin.TwinModel.project_tbrom_on_mesh` was previously called with named selections
+            (once or multiple times), returns a dictionary mapping each projected named selection name
             to its PyVista DataSet.
 
 

--- a/src/ansys/pytwin/evaluate/twin_model.py
+++ b/src/ansys/pytwin/evaluate/twin_model.py
@@ -1963,62 +1963,6 @@ class TwinModel(Model):
             msg += f"\n{str(e)}."
             self._raise_error(msg)
 
-    def tbrom_data_extract(self, rom_name: str, named_selection: str, data: np.ndarray):
-        """
-        Given a full-field data array, this method returns only the data values 
-        associated with the points in the given named selection of the given TBROM. If no named
-        selection is provided, the full data array is returned unchanged.
-
-        Parameters
-        ----------
-        rom_name : str
-            Name of the TBROM associated to the named selection. To get a list of available
-            TBROMs, see the :attr:`pytwin.TwinModel.tbrom_names` attribute.
-        named_selection : str or None
-            Name of the named selection that defines the subset of points to extract. If
-            ``None``, the full data array is returned without filtering. To get a list of
-            available named selections, use the
-            :func:`pytwin.TwinModel.get_named_selections` method.
-        data : numpy.ndarray
-            Full-field data array from which the subset is extracted. 
-
-        Returns
-        -------
-        numpy.ndarray
-            Subset of the data array corresponding to the points in the named selection,
-            sorted by point index. If ``named_selection`` is ``None``, the original
-            ``data`` array is returned.
-
-        Raises
-        ------
-        TwinModelError:
-            If ``rom_name`` is not included in the twin model's list of TBROMs.
-            If ``named_selection`` is not included in the TBROM's list of named selections.
-
-        Examples
-        --------
-        >>> import numpy as np
-        >>> from pytwin import TwinModel
-        >>> model = TwinModel(model_filepath='path_to_twin_model_with_TBROM_in_it.twin')
-        >>> model.initialize_evaluation()
-        >>> romname = model.tbrom_names[0]
-        >>> field_data = model.get_tbrom_output_field(romname)
-        >>> ns_list = model.get_named_selections(romname)
-        >>> extracted_data = model.tbrom_data_extract(romname, ns_list[0], field_data)
-        """
-        tbrom = None
-        if self._check_rom_name_is_valid(rom_name):
-            tbrom = self._tbroms[rom_name]
-        if named_selection is not None:
-            if named_selection not in tbrom.named_selections:
-                msg = self._error_msg_for_unknown_named_selection(named_selection, tbrom)
-                raise self._raise_error(msg)
-            pointsids = tbrom._named_selection_indexes(named_selection)
-            listids = np.sort(pointsids)
-            return data[listids]
-        else:
-            return data
-    
     def project_tbrom_on_mesh(
         self,
         rom_name: str,

--- a/src/ansys/pytwin/evaluate/twin_model.py
+++ b/src/ansys/pytwin/evaluate/twin_model.py
@@ -1963,6 +1963,62 @@ class TwinModel(Model):
             msg += f"\n{str(e)}."
             self._raise_error(msg)
 
+    def tbrom_data_extract(self, rom_name: str, named_selection: str, data: np.ndarray):
+        """
+        Given a full-field data array, this method returns only the data values 
+        associated with the points in the given named selection of the given TBROM. If no named
+        selection is provided, the full data array is returned unchanged.
+
+        Parameters
+        ----------
+        rom_name : str
+            Name of the TBROM associated to the named selection. To get a list of available
+            TBROMs, see the :attr:`pytwin.TwinModel.tbrom_names` attribute.
+        named_selection : str or None
+            Name of the named selection that defines the subset of points to extract. If
+            ``None``, the full data array is returned without filtering. To get a list of
+            available named selections, use the
+            :func:`pytwin.TwinModel.get_named_selections` method.
+        data : numpy.ndarray
+            Full-field data array from which the subset is extracted. 
+
+        Returns
+        -------
+        numpy.ndarray
+            Subset of the data array corresponding to the points in the named selection,
+            sorted by point index. If ``named_selection`` is ``None``, the original
+            ``data`` array is returned.
+
+        Raises
+        ------
+        TwinModelError:
+            If ``rom_name`` is not included in the twin model's list of TBROMs.
+            If ``named_selection`` is not included in the TBROM's list of named selections.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from pytwin import TwinModel
+        >>> model = TwinModel(model_filepath='path_to_twin_model_with_TBROM_in_it.twin')
+        >>> model.initialize_evaluation()
+        >>> romname = model.tbrom_names[0]
+        >>> field_data = model.get_tbrom_output_field(romname)
+        >>> ns_list = model.get_named_selections(romname)
+        >>> extracted_data = model.tbrom_data_extract(romname, ns_list[0], field_data)
+        """
+        tbrom = None
+        if self._check_rom_name_is_valid(rom_name):
+            tbrom = self._tbroms[rom_name]
+        if named_selection is not None:
+            if named_selection not in tbrom.named_selections:
+                msg = self._error_msg_for_unknown_named_selection(named_selection, tbrom)
+                raise self._raise_error(msg)
+            pointsids = tbrom._named_selection_indexes(named_selection)
+            listids = np.sort(pointsids)
+            return data[listids]
+        else:
+            return data
+    
     def project_tbrom_on_mesh(
         self,
         rom_name: str,

--- a/tests/evaluate/test_tbrom.py
+++ b/tests/evaluate/test_tbrom.py
@@ -1602,7 +1602,6 @@ class TestTbRom:
         except TwinModelError as e:
             assert "[RomOutputConnection]" in str(e)
 
-
     def test_tbrom_get_output_field_on_mesh_no_named_selection(self):
         """
         After project_tbrom_on_mesh without named selection, get_tbrom_output_field_on_mesh
@@ -1635,7 +1634,6 @@ class TestTbRom:
         twinmodel.evaluate_step_by_step(step_size=0.1, field_inputs={romname: {fieldname: zero_snapshot}})
         field_after = field_on_mesh[twinmodel.get_field_output_name(romname)]
         assert not np.allclose(field_before, field_after)
-
 
     def test_tbrom_get_output_field_on_mesh_with_named_selections(self):
         """
@@ -1677,7 +1675,6 @@ class TestTbRom:
         for ns in nslist:
             assert not np.allclose(fields_before[ns], fields_after[ns])
 
-
     def test_tbrom_get_output_field_on_mesh_partial_named_selections(self):
         """
         If only a subset of named selections have been projected, get_tbrom_output_field_on_mesh
@@ -1701,6 +1698,7 @@ class TestTbRom:
         assert isinstance(field_on_mesh, dict)
         assert nslist[0] in field_on_mesh
         assert nslist[1] not in field_on_mesh
+
 
 #    def test_tbrom_dynarom(self): # wait for seg fault error to be resolved
 #        model_filepath = TEST_TB_ROM_DROM

--- a/tests/evaluate/test_tbrom.py
+++ b/tests/evaluate/test_tbrom.py
@@ -1548,6 +1548,159 @@ class TestTbRom:
         assert "Parametric Field History : True" in output
         twinmodel.close()
 
+    def test_tbrom_get_output_field_on_mesh_errors(self):
+        reinit_settings()
+        romname = "unknown"
+        model_filepath = COUPLE_CLUTCHES_FILEPATH
+
+        # Raise an exception if no tbrom available in the twin
+        twinmodel = TwinModel(model_filepath=model_filepath)
+        try:
+            twinmodel.get_tbrom_output_field_on_mesh(romname)
+        except TwinModelError as e:
+            assert "[NoRom]" in str(e)
+
+        # Raise an exception if unknown rom name is given
+        model_filepath = download_file("ThermalTBROM_FieldInput_23R1.twin", "twin_files")
+        twinmodel = TwinModel(model_filepath=model_filepath)
+        twinmodel.initialize_evaluation()
+        try:
+            twinmodel.get_tbrom_output_field_on_mesh(romname)
+        except TwinModelError as e:
+            assert "[RomName]" in str(e)
+
+        # Raise an exception if project_tbrom_on_mesh has not been called yet (no-NS case: _meshdata is None)
+        model_filepath = download_file("ThermalTBROM_23R1_other.twin", "twin_files")
+        twinmodel = TwinModel(model_filepath=model_filepath)
+        twinmodel.initialize_evaluation()
+        romname = twinmodel.tbrom_names[0]
+        try:
+            twinmodel.get_tbrom_output_field_on_mesh(romname)
+        except TwinModelError as e:
+            assert "[NoProjection]" in str(e)
+
+        # Raise an exception if project_tbrom_on_mesh has not been called yet (NS case: _meshdata is empty dict {})
+        model_filepath = download_file("ThermalTBROM_FieldInput_23R1.twin", "twin_files")
+        twinmodel = TwinModel(model_filepath=model_filepath)
+        twinmodel.initialize_evaluation()
+        romname = twinmodel.tbrom_names[0]
+        try:
+            twinmodel.get_tbrom_output_field_on_mesh(romname)
+        except TwinModelError as e:
+            assert "[NoProjection]" in str(e)
+
+        # Raise an exception if the twin considered has no output MC connected
+        model_filepath = download_file("ThermalTBROM_23R1_other.twin", "twin_files")
+        twinmodel = TwinModel(model_filepath=model_filepath)
+        twinmodel.initialize_evaluation()
+        romname = twinmodel.tbrom_names[0]
+        mesh = pv.read(MESH_FILE)
+        # project_tbrom_on_mesh itself will raise [RomOutputConnection], so test directly on tbrom
+        twinmodel._tbroms[romname]._meshdata = mesh  # bypass projection
+        try:
+            twinmodel.get_tbrom_output_field_on_mesh(romname)
+        except TwinModelError as e:
+            assert "[RomOutputConnection]" in str(e)
+
+
+    def test_tbrom_get_output_field_on_mesh_no_named_selection(self):
+        """
+        After project_tbrom_on_mesh without named selection, get_tbrom_output_field_on_mesh
+        returns a single pv.DataSet (not a dict) and its field data is updated on evaluation.
+        """
+        reinit_settings()
+        model_filepath = download_file("ThermalTBROM_FieldInput_23R1.twin", "twin_files")
+        twinmodel = TwinModel(model_filepath=model_filepath)
+        romname = twinmodel.tbrom_names[0]
+        fieldname = twinmodel.get_field_input_names(romname)[0]
+        twinmodel.initialize_evaluation(field_inputs={romname: {fieldname: INPUT_SNAPSHOT}})
+        mesh = pv.read(MESH_FILE)
+
+        # Project on mesh without named selection
+        result = twinmodel.project_tbrom_on_mesh(romname, mesh, False)
+        assert result is not None
+        assert isinstance(result, pv.DataSet)
+
+        # get_tbrom_output_field_on_mesh returns same object (not a dict)
+        field_on_mesh = twinmodel.get_tbrom_output_field_on_mesh(romname)
+        assert field_on_mesh is result
+
+        # Field data is updated after a step evaluation with different input
+        fieldname = twinmodel.get_field_input_names(romname)[0]
+        zero_snapshot = np.zeros_like(read_binary(INPUT_SNAPSHOT))
+        twinmodel.initialize_evaluation(field_inputs={romname: {fieldname: INPUT_SNAPSHOT}})
+        result = twinmodel.project_tbrom_on_mesh(romname, mesh, False)
+        field_on_mesh = twinmodel.get_tbrom_output_field_on_mesh(romname)
+        field_before = field_on_mesh[twinmodel.get_field_output_name(romname)].copy()
+        twinmodel.evaluate_step_by_step(step_size=0.1, field_inputs={romname: {fieldname: zero_snapshot}})
+        field_after = field_on_mesh[twinmodel.get_field_output_name(romname)]
+        assert not np.allclose(field_before, field_after)
+
+
+    def test_tbrom_get_output_field_on_mesh_with_named_selections(self):
+        """
+        After project_tbrom_on_mesh with named selections, get_tbrom_output_field_on_mesh
+        returns a dict keyed by named selection name; each value is a pv.DataSet.
+        Field data in the dict is updated on evaluation.
+        """
+        reinit_settings()
+        model_filepath = download_file("ThermalTBROM_FieldInput_23R1.twin", "twin_files")
+        twinmodel = TwinModel(model_filepath=model_filepath)
+        romname = twinmodel.tbrom_names[0]
+        fieldname = twinmodel.get_field_input_names(romname)[0]
+        twinmodel.initialize_evaluation(field_inputs={romname: {fieldname: INPUT_SNAPSHOT}})
+        nslist = twinmodel.get_named_selections(romname)
+        assert len(nslist) >= 2
+        mesh = pv.read(MESH_FILE)
+
+        # Project each named selection onto the mesh
+        for ns in nslist:
+            result = twinmodel.project_tbrom_on_mesh(romname, mesh, False, ns)
+            assert result is not None
+            assert isinstance(result, dict)
+
+        # get_tbrom_output_field_on_mesh returns a dict with all projected named selections
+        field_on_mesh = twinmodel.get_tbrom_output_field_on_mesh(romname)
+        assert isinstance(field_on_mesh, dict)
+        for ns in nslist:
+            assert ns in field_on_mesh
+            assert isinstance(field_on_mesh[ns], pv.DataSet)
+
+        # Field data in each entry of the dict is updated after a step evaluation with different input
+        fieldname = twinmodel.get_field_input_names(romname)[0]
+        zero_snapshot = np.zeros_like(read_binary(INPUT_SNAPSHOT))
+        field_name = twinmodel.get_field_output_name(romname)
+        fields_before = {ns: field_on_mesh[ns][field_name].copy() for ns in nslist}
+        twinmodel.evaluate_step_by_step(step_size=0.1, field_inputs={romname: {fieldname: zero_snapshot}})
+        field_on_mesh = twinmodel.get_tbrom_output_field_on_mesh(romname)
+        fields_after = {ns: field_on_mesh[ns][field_name] for ns in nslist}
+        for ns in nslist:
+            assert not np.allclose(fields_before[ns], fields_after[ns])
+
+
+    def test_tbrom_get_output_field_on_mesh_partial_named_selections(self):
+        """
+        If only a subset of named selections have been projected, get_tbrom_output_field_on_mesh
+        returns a dict containing only those that were projected (not empty).
+        """
+        reinit_settings()
+        model_filepath = download_file("ThermalTBROM_FieldInput_23R1.twin", "twin_files")
+        twinmodel = TwinModel(model_filepath=model_filepath)
+        romname = twinmodel.tbrom_names[0]
+        fieldname = twinmodel.get_field_input_names(romname)[0]
+        twinmodel.initialize_evaluation(field_inputs={romname: {fieldname: INPUT_SNAPSHOT}})
+        nslist = twinmodel.get_named_selections(romname)
+        assert len(nslist) >= 2
+        mesh = pv.read(MESH_FILE)
+
+        # Project only the first named selection
+        twinmodel.project_tbrom_on_mesh(romname, mesh, False, nslist[0])
+
+        # get_tbrom_output_field_on_mesh should succeed (dict is non-empty)
+        field_on_mesh = twinmodel.get_tbrom_output_field_on_mesh(romname)
+        assert isinstance(field_on_mesh, dict)
+        assert nslist[0] in field_on_mesh
+        assert nslist[1] not in field_on_mesh
 
 #    def test_tbrom_dynarom(self): # wait for seg fault error to be resolved
 #        model_filepath = TEST_TB_ROM_DROM

--- a/tests/evaluate/test_tbrom.py
+++ b/tests/evaluate/test_tbrom.py
@@ -1657,7 +1657,7 @@ class TestTbRom:
         for ns in nslist:
             result = twinmodel.project_tbrom_on_mesh(romname, mesh, False, ns)
             assert result is not None
-            assert isinstance(result, dict)
+            assert isinstance(result, pv.DataSet)
 
         # get_tbrom_output_field_on_mesh returns a dict with all projected named selections
         field_on_mesh = twinmodel.get_tbrom_output_field_on_mesh(romname)

--- a/tests/evaluate/test_tbrom.py
+++ b/tests/evaluate/test_tbrom.py
@@ -1548,6 +1548,55 @@ class TestTbRom:
         assert "Parametric Field History : True" in output
         twinmodel.close()
 
+    def test_tbrom_data_extract_is_ok(self):
+        """
+        TEST_TB_ROM12
+        Twin with 1 TBROM, output field connected, named selections ['Group_1', 'Group_2'].
+        Full field: 104422 points x 3 components = 313266 elements (flat).
+        Group_1 NS: 26198 points x 3 components = 78594 elements (flat).
+        """
+        model_filepath = TEST_TB_ROM12
+        twinmodel = TwinModel(model_filepath=model_filepath)
+        twinmodel.initialize_evaluation()
+        romname = twinmodel.tbrom_names[0]
+        ns_list = twinmodel.get_named_selections(romname)
+
+        # Generate full-field snapshot in memory: shape (nb_points, dim)
+        full_field = twinmodel.generate_snapshot(romname, on_disk=False)
+
+        # named_selection=None -> original data object returned unchanged (same reference)
+        result_no_ns = twinmodel.tbrom_data_extract(romname, None, full_field)
+        assert result_no_ns is full_field
+
+        # Valid named selection -> subset matching generate_snapshot with that NS
+        result_ns = twinmodel.tbrom_data_extract(romname, ns_list[0], full_field)
+        assert result_ns.reshape(-1).shape[0] == 78594
+
+        snp_ns = twinmodel.generate_snapshot(romname, on_disk=False, named_selection=ns_list[0])
+        assert np.allclose(result_ns, snp_ns)
+
+    def test_tbrom_data_extract_exceptions(self):
+        """
+        TEST_TB_ROM12
+        Verify that tbrom_data_extract raises TwinModelError for invalid rom_name or named_selection.
+        """
+        model_filepath = TEST_TB_ROM12
+        twinmodel = TwinModel(model_filepath=model_filepath)
+        twinmodel.initialize_evaluation()
+        romname = twinmodel.tbrom_names[0]
+        full_field = twinmodel.generate_snapshot(romname, on_disk=False)
+
+        # Raise an exception if rom name is unknown
+        try:
+            twinmodel.tbrom_data_extract("unknown_rom", None, full_field)
+        except TwinModelError as e:
+            assert "[RomName]" in str(e)
+
+        # Raise an exception if named selection is unknown
+        try:
+            twinmodel.tbrom_data_extract(romname, "unknown_ns", full_field)
+        except TwinModelError as e:
+            assert "[NamedSelection]" in str(e)
 
 #    def test_tbrom_dynarom(self): # wait for seg fault error to be resolved
 #        model_filepath = TEST_TB_ROM_DROM

--- a/tests/evaluate/test_tbrom.py
+++ b/tests/evaluate/test_tbrom.py
@@ -1548,55 +1548,6 @@ class TestTbRom:
         assert "Parametric Field History : True" in output
         twinmodel.close()
 
-    def test_tbrom_data_extract_is_ok(self):
-        """
-        TEST_TB_ROM12
-        Twin with 1 TBROM, output field connected, named selections ['Group_1', 'Group_2'].
-        Full field: 104422 points x 3 components = 313266 elements (flat).
-        Group_1 NS: 26198 points x 3 components = 78594 elements (flat).
-        """
-        model_filepath = TEST_TB_ROM12
-        twinmodel = TwinModel(model_filepath=model_filepath)
-        twinmodel.initialize_evaluation()
-        romname = twinmodel.tbrom_names[0]
-        ns_list = twinmodel.get_named_selections(romname)
-
-        # Generate full-field snapshot in memory: shape (nb_points, dim)
-        full_field = twinmodel.generate_snapshot(romname, on_disk=False)
-
-        # named_selection=None -> original data object returned unchanged (same reference)
-        result_no_ns = twinmodel.tbrom_data_extract(romname, None, full_field)
-        assert result_no_ns is full_field
-
-        # Valid named selection -> subset matching generate_snapshot with that NS
-        result_ns = twinmodel.tbrom_data_extract(romname, ns_list[0], full_field)
-        assert result_ns.reshape(-1).shape[0] == 78594
-
-        snp_ns = twinmodel.generate_snapshot(romname, on_disk=False, named_selection=ns_list[0])
-        assert np.allclose(result_ns, snp_ns)
-
-    def test_tbrom_data_extract_exceptions(self):
-        """
-        TEST_TB_ROM12
-        Verify that tbrom_data_extract raises TwinModelError for invalid rom_name or named_selection.
-        """
-        model_filepath = TEST_TB_ROM12
-        twinmodel = TwinModel(model_filepath=model_filepath)
-        twinmodel.initialize_evaluation()
-        romname = twinmodel.tbrom_names[0]
-        full_field = twinmodel.generate_snapshot(romname, on_disk=False)
-
-        # Raise an exception if rom name is unknown
-        try:
-            twinmodel.tbrom_data_extract("unknown_rom", None, full_field)
-        except TwinModelError as e:
-            assert "[RomName]" in str(e)
-
-        # Raise an exception if named selection is unknown
-        try:
-            twinmodel.tbrom_data_extract(romname, "unknown_ns", full_field)
-        except TwinModelError as e:
-            assert "[NamedSelection]" in str(e)
 
 #    def test_tbrom_dynarom(self): # wait for seg fault error to be resolved
 #        model_filepath = TEST_TB_ROM_DROM


### PR DESCRIPTION
This pull request enhances the TBROM mesh projection and output retrieval workflow in the `pytwin` package. The main improvements include robust support for handling multiple named selections during mesh projection, the introduction of a new public API to retrieve TBROM output fields on mesh, improved error handling, and comprehensive tests for these new capabilities.

**Key changes:**

### TBROM mesh projection and retrieval enhancements

* Refactored the handling of mesh data (`_meshdata`) and output mesh basis (`_outmeshbasis`) in `TBROM` objects to support both single (full-domain) and multiple (named selection) projections, storing them as either a single object or a dictionary keyed by named selection. This ensures correct management and updating of mesh data for each projection scenario. 
* Added the new public method `get_tbrom_output_field_on_mesh` to `TwinModel`, allowing users to retrieve the projected TBROM output field as a PyVista DataSet (for full-domain) or a dictionary of DataSets (for named selections). This method includes detailed documentation and usage examples.
* Modified `project_tbrom_on_mesh` to return the projected mesh data object directly, improving clarity and usability of the API. 

### Error handling improvements

* Introduced a new error message method `_error_msg_for_not_projection` to provide informative feedback if mesh projection has not been performed before attempting to retrieve output fields on mesh.
* Enhanced `get_tbrom_output_field_on_mesh` to raise descriptive errors for missing TBROMs, unknown ROM names, missing projections, and missing output MC connections, improving the robustness of the API.

### Testing and validation

* Added comprehensive tests to verify the new mesh projection and retrieval logic, including error scenarios, correct object types returned, field data updates after evaluation, and partial named selection projections. These tests ensure correctness and reliability of the new features.