### PR TITLE
Fix Linux testing coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,7 @@ jobs:
       - name: Combine parallel coverage data (Linux only)
         if: matrix.os == 'ubuntu-22.04'
         run: |
+          pip install coverage[toml]
           python -m coverage combine
           python -m coverage xml -o .cov/coverage.xml
           python -m coverage html -d .cov/html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,34 +167,6 @@ jobs:
           ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
           COVERAGE_PROCESS_START: pyproject.toml
 
-      # On Linux, forked children write separate .coverage.* files.
-      # Combine them all into one before generating reports.
-      - name: Combine parallel coverage data (Linux only)
-        if: matrix.os == 'ubuntu-22.04'
-        run: |
-          pip install coverage[toml]
-          shopt -s nullglob
-          files=(.coverage.*)
-          if [ ${#files[@]} -gt 0 ]; then
-            echo "Found ${#files[@]} parallel coverage files - combining"
-            python -m coverage combine
-            python -m coverage xml -o .cov/coverage.xml
-            python -m coverage html -d .cov/html
-          else
-            echo "No parallel coverage files found - pytest-cov already combined them"
-          fi
-
-      # TEMPORARY DIAGNOSTIC - remove before merging to main
-      - name: Diagnose parallel coverage (Linux only)
-        if: matrix.os == 'ubuntu-22.04'
-        run: |
-          pip install coverage[toml]
-          echo "=== .coverage data file ==="
-          ls -lh .coverage 2>/dev/null || echo "WARNING: .coverage NOT found"
-          echo ""
-          echo "=== Coverage for tbrom module (should be non-zero if fork fix works) ==="
-          python -m coverage report --include="*/pytwin/evaluate/tbrom*" --show-missing || echo "No coverage data available"
-
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,17 @@ jobs:
           python -m coverage xml -o .cov/coverage.xml
           python -m coverage html -d .cov/html
 
+      # TEMPORARY DIAGNOSTIC - remove before merging to main
+      - name: Diagnose parallel coverage files (Linux only)
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          echo "=== .coverage.* files written by forked children ==="
+          ls -lh .coverage.* 2>/dev/null || echo "NONE FOUND - fix is not working"
+          echo "Total child data files: $(ls .coverage.* 2>/dev/null | wc -l)"
+          echo ""
+          echo "=== Combined coverage summary (after combine) ==="
+          python -m coverage report --include="*/pytwin/evaluate/tbrom*" --show-missing
+
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,20 +173,27 @@ jobs:
         if: matrix.os == 'ubuntu-22.04'
         run: |
           pip install coverage[toml]
-          python -m coverage combine
-          python -m coverage xml -o .cov/coverage.xml
-          python -m coverage html -d .cov/html
+          shopt -s nullglob
+          files=(.coverage.*)
+          if [ ${#files[@]} -gt 0 ]; then
+            echo "Found ${#files[@]} parallel coverage files - combining"
+            python -m coverage combine
+            python -m coverage xml -o .cov/coverage.xml
+            python -m coverage html -d .cov/html
+          else
+            echo "No parallel coverage files found - pytest-cov already combined them"
+          fi
 
       # TEMPORARY DIAGNOSTIC - remove before merging to main
-      - name: Diagnose parallel coverage files (Linux only)
+      - name: Diagnose parallel coverage (Linux only)
         if: matrix.os == 'ubuntu-22.04'
         run: |
-          echo "=== .coverage.* files written by forked children ==="
-          ls -lh .coverage.* 2>/dev/null || echo "NONE FOUND - fix is not working"
-          echo "Total child data files: $(ls .coverage.* 2>/dev/null | wc -l)"
+          pip install coverage[toml]
+          echo "=== .coverage data file ==="
+          ls -lh .coverage 2>/dev/null || echo "WARNING: .coverage NOT found"
           echo ""
-          echo "=== Combined coverage summary (after combine) ==="
-          python -m coverage report --include="*/pytwin/evaluate/tbrom*" --show-missing
+          echo "=== Coverage for tbrom module (should be non-zero if fork fix works) ==="
+          python -m coverage report --include="*/pytwin/evaluate/tbrom*" --show-missing || echo "No coverage data available"
 
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,16 @@ jobs:
           pytest-extra-args: "--cov=pytwin --cov-report=term --cov-report=xml:.cov/coverage.xml --cov-report=html:.cov/html"
         env:
           ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
+          COVERAGE_PROCESS_START: pyproject.toml
+
+      # On Linux, forked children write separate .coverage.* files.
+      # Combine them all into one before generating reports.
+      - name: Combine parallel coverage data (Linux only)
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          python -m coverage combine
+          python -m coverage xml -o .cov/coverage.xml
+          python -m coverage html -d .cov/html
 
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ src_paths = ["doc", "src", "tests"]
 ignore-words = "doc/styles/config/vocabularies/ANSYS/accept.txt"
 
 [tool.coverage.run]
+concurrency = ["multiprocessing"]
 source = ["ansys.pytwin"]
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ src_paths = ["doc", "src", "tests"]
 ignore-words = "doc/styles/config/vocabularies/ANSYS/accept.txt"
 
 [tool.coverage.run]
-concurrency = ["multiprocessing"]
+parallel = true
 source = ["ansys.pytwin"]
 
 [tool.coverage.report]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ def pytest_collection_modifyitems(config, items):
             if "TestTbRom" in item.nodeid:
                 item.add_marker(pytest.mark.forked)
 
+
 # ---------------------------------------------------------------------------
 # Coverage support for os.fork() + os._exit() used by pytest-forked on Linux
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 # conftest.py
+import os
 import sys
 
 import pytest
@@ -31,3 +32,54 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "TestTbRom" in item.nodeid:
                 item.add_marker(pytest.mark.forked)
+
+# ---------------------------------------------------------------------------
+# Coverage support for os.fork() + os._exit() used by pytest-forked on Linux
+# ---------------------------------------------------------------------------
+# pytest-forked forks a child with os.fork() and terminates it with os._exit(),
+# which bypasses all Python cleanup (atexit, __del__, coverage finalisation).
+# We wrap os.fork() so that the child:
+#   1. Stops the inherited parent coverage instance (to avoid double-counting).
+#   2. Starts a NEW coverage instance with a unique parallel data suffix.
+#   3. Patches os._exit() to flush that data before the hard exit.
+# ---------------------------------------------------------------------------
+if sys.platform == "linux" and hasattr(os, "fork") and os.environ.get("COVERAGE_PROCESS_START"):
+
+    import coverage as _coverage_module
+
+    _real_fork = os.fork
+
+    def _coverage_aware_fork():
+        pid = _real_fork()
+
+        if pid == 0:
+            # ---- We are in the forked child process ----
+
+            # 1. Stop and discard the inherited parent coverage instance so it
+            #    does not interfere or write to the parent's data file.
+            existing = _coverage_module.Coverage.current()
+            if existing is not None:
+                existing.stop()
+
+            # 2. Start a brand-new coverage instance.
+            #    data_suffix=True makes coverage.py append .HOSTNAME.PID.RANDOM
+            #    to the filename, ensuring each child writes a unique file.
+            _child_cov = _coverage_module.Coverage(
+                config_file=os.environ["COVERAGE_PROCESS_START"],
+                data_suffix=True,
+            )
+            _child_cov.start()
+
+            # 3. Patch os._exit so coverage is saved before the hard kill.
+            _real_exit = os._exit
+
+            def _exit_with_coverage_save(code):
+                _child_cov.stop()
+                _child_cov.save()
+                _real_exit(code)
+
+            os._exit = _exit_with_coverage_save
+
+        return pid
+
+    os.fork = _coverage_aware_fork

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,10 +39,10 @@ def pytest_collection_modifyitems(config, items):
 # ---------------------------------------------------------------------------
 # pytest-forked forks a child with os.fork() and terminates it with os._exit(),
 # which bypasses all Python cleanup (atexit, __del__, coverage finalisation).
-# We wrap os.fork() so that the child:
-#   1. Stops the inherited parent coverage instance (to avoid double-counting).
-#   2. Starts a NEW coverage instance with a unique parallel data suffix.
-#   3. Patches os._exit() to flush that data before the hard exit.
+# We wrap os.fork() so that the child patches os._exit() to flush the
+# already-running pytest-cov coverage instance before the hard exit.
+# parallel=true in pyproject.toml ensures each child writes a uniquely-named
+# .coverage.<host>.<pid>.<rand> file; pytest-cov combines them at session end.
 # ---------------------------------------------------------------------------
 if sys.platform == "linux" and hasattr(os, "fork") and os.environ.get("COVERAGE_PROCESS_START"):
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,29 +54,19 @@ if sys.platform == "linux" and hasattr(os, "fork") and os.environ.get("COVERAGE_
         pid = _real_fork()
 
         if pid == 0:
-            # ---- We are in the forked child process ----
-
-            # 1. Stop and discard the inherited parent coverage instance so it
-            #    does not interfere or write to the parent's data file.
-            existing = _coverage_module.Coverage.current()
-            if existing is not None:
-                existing.stop()
-
-            # 2. Start a brand-new coverage instance.
-            #    data_suffix=True makes coverage.py append .HOSTNAME.PID.RANDOM
-            #    to the filename, ensuring each child writes a unique file.
-            _child_cov = _coverage_module.Coverage(
-                config_file=os.environ["COVERAGE_PROCESS_START"],
-                data_suffix=True,
-            )
-            _child_cov.start()
-
-            # 3. Patch os._exit so coverage is saved before the hard kill.
+            # In the forked child: patch os._exit to save pytest-cov's
+            # already-running coverage before the hard exit (which bypasses
+            # atexit and all normal Python cleanup).
             _real_exit = os._exit
 
             def _exit_with_coverage_save(code):
-                _child_cov.stop()
-                _child_cov.save()
+                cov = _coverage_module.Coverage.current()
+                if cov is not None:
+                    try:
+                        cov.stop()
+                        cov.save()  # parallel=true → writes .coverage.<host>.<pid>.<rand>
+                    except Exception:
+                        pass
                 _real_exit(code)
 
             os._exit = _exit_with_coverage_save


### PR DESCRIPTION
This pull request improves test coverage reporting when using `pytest-forked` on Linux by ensuring that coverage data is properly collected from forked processes. It introduces a patch to handle coverage collection in subprocesses and updates configuration to support parallel coverage files.

**Test coverage improvements:**

* Added a wrapper around `os.fork()` in `tests/conftest.py` to patch `os._exit()` in forked child processes, ensuring that coverage data is saved before hard exit, which is necessary because `pytest-forked` bypasses normal Python cleanup.
* Set the `COVERAGE_PROCESS_START` environment variable in the CI workflow to trigger coverage collection in subprocesses. (`.github/workflows/ci.yml`)
* Enabled `parallel = true` in the coverage configuration to allow each subprocess to write its own coverage data file, which can be combined at the end of the test session. (`pyproject.toml`)

**Codebase maintenance:**

* Added an import for `os` in `tests/conftest.py` to support the new coverage handling logic.