### PR TITLE
add getter for ROM data location

### DIFF
--- a/src/ansys/pytwin/evaluate/tbrom.py
+++ b/src/ansys/pytwin/evaluate/tbrom.py
@@ -806,7 +806,7 @@ class TbRom:
     def field_output_unit(self):
         """Return the field output unit."""
         return self._outunit
-    
+
     @property
     def field_output_data_location(self):
         """Return the data location of the field output."""

--- a/src/ansys/pytwin/evaluate/tbrom.py
+++ b/src/ansys/pytwin/evaluate/tbrom.py
@@ -200,6 +200,11 @@ def _read_settings(filepath):
     else:
         timegrid = None
 
+    if "location" in data:
+        location = data["location"]
+    else:
+        location = "elemental"
+
     tbromns = dict()
 
     # Create list of name selections indexes
@@ -214,7 +219,7 @@ def _read_settings(filepath):
             i = i + 1
         tbromns.update({name: idsListNp})
 
-    return [tbromns, dimensionality, outputname, unit, timegrid]
+    return [tbromns, dimensionality, outputname, unit, timegrid, location]
 
 
 def _read_properties(filepath):
@@ -294,7 +299,7 @@ class TbRom:
 
         settingspath = os.path.join(tbrom_path, TbRom.OUT_F_KEY, TbRom.TBROM_SET)
         if os.path.exists(settingspath):
-            [nsidslist, dimensionality, outputname, unit, timegrid] = _read_settings(settingspath)
+            [nsidslist, dimensionality, outputname, unit, timegrid, location] = _read_settings(settingspath)
         else:
             raise ValueError("Settings file {} does not exist.".format(settingspath))
 
@@ -334,6 +339,7 @@ class TbRom:
         self._outname = outputname
         self._outunit = unit
         self._outputfilespath = None
+        self._outputlocation = location
 
         # bug 1168769 (fixed in 2025R2)
         pointpath = os.path.join(tbrom_path, TbRom.OUT_F_KEY, TbRom.TBROM_POINTS)
@@ -800,6 +806,11 @@ class TbRom:
     def field_output_unit(self):
         """Return the field output unit."""
         return self._outunit
+    
+    @property
+    def field_output_data_location(self):
+        """Return the data location of the field output."""
+        return self._outputlocation
 
     @property
     def named_selections(self):

--- a/src/ansys/pytwin/evaluate/twin_model.py
+++ b/src/ansys/pytwin/evaluate/twin_model.py
@@ -1608,7 +1608,7 @@ class TwinModel(Model):
 
         return tbrom.field_output_name
 
-    def get_field_output_data_location(self, rom_name):
+    def get_tbrom_data_location(self, rom_name):
         """
         Get the data location (elemental or Nodal) of the output field associated to the TBROM named rom_name.
 
@@ -1628,9 +1628,9 @@ class TwinModel(Model):
         --------
         >>> from pytwin import TwinModel
         >>> model = TwinModel(model_filepath='path_to_twin_model_with_TBROM_in_it.twin')
-        >>> model.get_field_output_data_location(model.tbrom_names[0])
+        >>> model.get_tbrom_data_location(model.tbrom_names[0])
         """
-        self._log_key = "GetFieldOutputDataLocation"
+        self._log_key = "GetTBROMDataLocation"
 
         if self.tbrom_info is None:
             msg = self._error_msg_no_tbrom()

--- a/src/ansys/pytwin/evaluate/twin_model.py
+++ b/src/ansys/pytwin/evaluate/twin_model.py
@@ -1607,7 +1607,7 @@ class TwinModel(Model):
         tbrom = self._tbroms[rom_name]
 
         return tbrom.field_output_name
-    
+
     def get_field_output_data_location(self, rom_name):
         """
         Get the data location (elemental or Nodal) of the output field associated to the TBROM named rom_name.

--- a/src/ansys/pytwin/evaluate/twin_model.py
+++ b/src/ansys/pytwin/evaluate/twin_model.py
@@ -1607,6 +1607,42 @@ class TwinModel(Model):
         tbrom = self._tbroms[rom_name]
 
         return tbrom.field_output_name
+    
+    def get_field_output_data_location(self, rom_name):
+        """
+        Get the data location (elemental or Nodal) of the output field associated to the TBROM named rom_name.
+
+        Parameters
+        ----------
+        rom_name : str
+            Name of the ROM. To get a list of available ROMs, see the
+            :attr:`pytwin.TwinModel.tbrom_names` attribute.
+
+        Raises
+        ------
+        TwinModelError:
+            If ``TwinModel`` object does not include any TBROMs.
+            If the provided ROM name is not available.
+
+        Examples
+        --------
+        >>> from pytwin import TwinModel
+        >>> model = TwinModel(model_filepath='path_to_twin_model_with_TBROM_in_it.twin')
+        >>> model.get_field_output_data_location(model.tbrom_names[0])
+        """
+        self._log_key = "GetFieldOutputDataLocation"
+
+        if self.tbrom_info is None:
+            msg = self._error_msg_no_tbrom()
+            self._raise_error(msg)
+
+        if rom_name not in self.tbrom_names:
+            msg = self._error_msg_for_rom_name(rom_name)
+            self._raise_error(msg)
+
+        tbrom = self._tbroms[rom_name]
+
+        return tbrom.field_output_data_location
 
     def get_snapshot_filepath(self, rom_name: str, evaluation_time: float = 0.0):
         """

--- a/tests/evaluate/test_tbrom.py
+++ b/tests/evaluate/test_tbrom.py
@@ -1425,7 +1425,7 @@ class TestTbRom:
 
     def test_tbrom_tensor_field(self):
         model_filepath = TEST_TB_ROM_TENSOR
-        [nsidslist, dimensionality, outputname, unit, timegrid] = tbrom._read_settings(
+        [nsidslist, dimensionality, outputname, unit, timegrid, location] = tbrom._read_settings(
             model_filepath
         )  # instantiation should be fine without points
         assert int(dimensionality[0]) is 6
@@ -1701,7 +1701,7 @@ class TestTbRom:
 
     def test_tbrom_get_data_location(self):
         reinit_settings()
-        model_filepath = download_file("ThermalTBROM_FieldInput_23R1.twin", "twin_files")
+        model_filepath = download_file("HXVelVectorTBROM_23R2.twin", "twin_files")
         twinmodel = TwinModel(model_filepath=model_filepath)
         romname = twinmodel.tbrom_names[0]
         location = twinmodel.get_tbrom_data_location(romname)

--- a/tests/evaluate/test_tbrom.py
+++ b/tests/evaluate/test_tbrom.py
@@ -1699,6 +1699,19 @@ class TestTbRom:
         assert nslist[0] in field_on_mesh
         assert nslist[1] not in field_on_mesh
 
+    def test_tbrom_get_output_field_data_location(self):
+        reinit_settings()
+        model_filepath = download_file("ThermalTBROM_FieldInput_23R1.twin", "twin_files")
+        twinmodel = TwinModel(model_filepath=model_filepath)
+        romname = twinmodel.tbrom_names[0]
+        location = twinmodel.get_field_output_data_location(romname)
+        assert location is "elemental"
+        model_filepath = download_file("FEADeformationTBROM_23R2.twin", "twin_files")
+        twinmodel = TwinModel(model_filepath=model_filepath)
+        romname = twinmodel.tbrom_names[0]
+        location = twinmodel.get_field_output_data_location(romname)
+        assert location is "Nodal"
+
 
 #    def test_tbrom_dynarom(self): # wait for seg fault error to be resolved
 #        model_filepath = TEST_TB_ROM_DROM

--- a/tests/evaluate/test_tbrom.py
+++ b/tests/evaluate/test_tbrom.py
@@ -1705,12 +1705,12 @@ class TestTbRom:
         twinmodel = TwinModel(model_filepath=model_filepath)
         romname = twinmodel.tbrom_names[0]
         location = twinmodel.get_tbrom_data_location(romname)
-        assert location is "elemental"
+        assert location=="elemental"
         model_filepath = download_file("FEADeformationTBROM_23R2.twin", "twin_files")
         twinmodel = TwinModel(model_filepath=model_filepath)
         romname = twinmodel.tbrom_names[0]
         location = twinmodel.get_tbrom_data_location(romname)
-        assert location is "Nodal"
+        assert location=="Nodal"
 
 
 #    def test_tbrom_dynarom(self): # wait for seg fault error to be resolved

--- a/tests/evaluate/test_tbrom.py
+++ b/tests/evaluate/test_tbrom.py
@@ -1705,12 +1705,12 @@ class TestTbRom:
         twinmodel = TwinModel(model_filepath=model_filepath)
         romname = twinmodel.tbrom_names[0]
         location = twinmodel.get_tbrom_data_location(romname)
-        assert location=="elemental"
+        assert location == "elemental"
         model_filepath = download_file("FEADeformationTBROM_23R2.twin", "twin_files")
         twinmodel = TwinModel(model_filepath=model_filepath)
         romname = twinmodel.tbrom_names[0]
         location = twinmodel.get_tbrom_data_location(romname)
-        assert location=="Nodal"
+        assert location == "Nodal"
 
 
 #    def test_tbrom_dynarom(self): # wait for seg fault error to be resolved

--- a/tests/evaluate/test_tbrom.py
+++ b/tests/evaluate/test_tbrom.py
@@ -1699,17 +1699,17 @@ class TestTbRom:
         assert nslist[0] in field_on_mesh
         assert nslist[1] not in field_on_mesh
 
-    def test_tbrom_get_output_field_data_location(self):
+    def test_tbrom_get_data_location(self):
         reinit_settings()
         model_filepath = download_file("ThermalTBROM_FieldInput_23R1.twin", "twin_files")
         twinmodel = TwinModel(model_filepath=model_filepath)
         romname = twinmodel.tbrom_names[0]
-        location = twinmodel.get_field_output_data_location(romname)
+        location = twinmodel.get_tbrom_data_location(romname)
         assert location is "elemental"
         model_filepath = download_file("FEADeformationTBROM_23R2.twin", "twin_files")
         twinmodel = TwinModel(model_filepath=model_filepath)
         romname = twinmodel.tbrom_names[0]
-        location = twinmodel.get_field_output_data_location(romname)
+        location = twinmodel.get_tbrom_data_location(romname)
         assert location is "Nodal"
 
 


### PR DESCRIPTION
This pull request adds support for retrieving the data location (e.g., "elemental" or "Nodal") of TBROM field outputs, making it accessible via both the TBROM class and the main TwinModel API. It also introduces a corresponding test to ensure the new functionality works as expected.

**Enhancements to TBROM field output metadata:**

* Extended the settings parsing and TBROM initialization in `tbrom.py` to read and store the field output data location, defaulting to "elemental" if not specified. (`_read_settings`, `TbRom.__init__`) 
* Added the `field_output_data_location` property to the TBROM class to provide access to the stored data location.

**API improvements in TwinModel:**

* Added the `get_tbrom_data_location` method to the `TwinModel` class, allowing users to query the data location for a given TBROM by name.

**Testing:**

* Added a test in `test_tbrom.py` to verify that the correct data location is returned for different TBROM models.